### PR TITLE
fix: 添加 getAllProjectsCreds 元素的 null 检查

### DIFF
--- a/front/common.js
+++ b/front/common.js
@@ -209,8 +209,9 @@ function getAuthHeaders() {
 // =====================================================================
 
 async function startAuth() {
-    const projectId = document.getElementById('projectId').value.trim();
-    const getAllProjects = document.getElementById('getAllProjectsCreds').checked;
+    const projectId = document.getElementById('projectId')?.value?.trim() || '';
+    const getAllProjectsEl = document.getElementById('getAllProjectsCreds');
+    const getAllProjects = getAllProjectsEl ? getAllProjectsEl.checked : false;
     // 项目ID现在是可选的
     currentProjectId = projectId || null;
 
@@ -271,7 +272,8 @@ async function getCredentials() {
     }
 
     const btn = document.getElementById('getCredsBtn');
-    const getAllProjects = document.getElementById('getAllProjectsCreds').checked;
+    const getAllProjectsEl = document.getElementById('getAllProjectsCreds');
+    const getAllProjects = getAllProjectsEl ? getAllProjectsEl.checked : false;
     btn.disabled = true;
     btn.textContent = getAllProjects ? '并发批量获取所有项目凭证中...' : '等待OAuth回调中...';
 
@@ -424,7 +426,8 @@ function toggleCallbackUrlSection() {
 async function processCallbackUrl() {
     const callbackUrlInput = document.getElementById('callbackUrlInput');
     const callbackUrl = callbackUrlInput.value.trim();
-    const getAllProjects = document.getElementById('getAllProjectsCreds').checked;
+    const getAllProjectsEl = document.getElementById('getAllProjectsCreds');
+    const getAllProjects = getAllProjectsEl ? getAllProjectsEl.checked : false;
 
     if (!callbackUrl) {
         showStatus('请输入回调URL', 'error');


### PR DESCRIPTION
## Summary
- 修复在非 OAuth 认证页面访问 `getAllProjectsCreds` 元素时的空指针异常
- 该元素仅存在于 OAuth 认证页面，在 Antigravity 认证页面调用相关函数时会报错：`Cannot read properties of null (reading 'checked')`

## 修复位置
- `startAuth()`: `projectId` 和 `getAllProjectsCreds` 的 null 检查
- `getCredentials()`: `getAllProjectsCreds` 的 null 检查
- `processCallbackUrl()`: `getAllProjectsCreds` 的 null 检查

## Test plan
- [ ] 在 OAuth 认证页面测试获取认证链接功能
- [ ] 在 Antigravity 认证页面测试获取认证链接功能
- [ ] 测试从回调 URL 获取凭证功能

🤖 Generated with [Claude Code](https://claude.com/claude-code)