### PR TITLE
fix: Remove unsupported JSON Schema fields from tool definitions

### DIFF
--- a/src/antigravity_router.py
+++ b/src/antigravity_router.py
@@ -240,9 +240,20 @@ def convert_openai_tools_to_antigravity(tools: Optional[List[Any]]) -> Optional[
     if not tools:
         return None
 
-    # 需要排除的字段
-    EXCLUDED_KEYS = {'$schema', 'additionalProperties', 'minLength', 'maxLength',
-                     'minItems', 'maxItems', 'uniqueItems'}
+    # 需要排除的字段 - 与 _clean_schema_for_gemini 保持一致
+    # Gemini/Antigravity API 不支持这些 JSON Schema 字段
+    # 参考: github.com/googleapis/python-genai/issues/699, #388, #460, #1122, #264, #4551
+    EXCLUDED_KEYS = {
+        '$schema', '$id', '$ref', '$defs', 'definitions',
+        'example', 'examples', 'readOnly', 'writeOnly', 'default',
+        'exclusiveMaximum', 'exclusiveMinimum',
+        'oneOf', 'anyOf', 'allOf', 'const',
+        'additionalItems', 'contains', 'patternProperties', 'dependencies',
+        'propertyNames', 'if', 'then', 'else',
+        'contentEncoding', 'contentMediaType',
+        'additionalProperties', 'minLength', 'maxLength',
+        'minItems', 'maxItems', 'uniqueItems'
+    }
 
     def clean_parameters(obj):
         """递归清理参数对象"""

--- a/src/openai_transfer.py
+++ b/src/openai_transfer.py
@@ -711,13 +711,13 @@ def _clean_schema_for_gemini(schema: Any) -> Any:
     # Gemini 不支持的字段（官方文档 + GitHub Issues 确认）
     # 参考: github.com/googleapis/python-genai/issues/699, #388, #460, #1122, #264, #4551
     # example (OpenAPI 3.0) 和 examples (JSON Schema) 都不支持
+    # 注意：title 在某些情况下是必需的，所以保留
     unsupported_keys = {
         "$schema",
         "$id",
         "$ref",
         "$defs",
         "definitions",
-        "title",
         "example",
         "examples",
         "readOnly",


### PR DESCRIPTION
- Fix compatibility with Zed IDE and other clients that send anyOf/const fields
- Add comprehensive tool schema cleaning for Gemini/Antigravity APIs
- Keep title field as it's required by Google API in certain contexts
- Remove unsupported fields: anyOf, oneOf, allOf, const, , etc.

Fixes #234