### PR TITLE
fix: 修复 message_start 事件中 usage 硬编码为 0 的问题

### DIFF
--- a/src/converter/anthropic2gemini.py
+++ b/src/converter/anthropic2gemini.py
@@ -1017,7 +1017,7 @@ async def gemini_stream_to_anthropic_stream(
                             "content": [],
                             "stop_reason": None,
                             "stop_sequence": None,
-                            "usage": {"input_tokens": 0, "output_tokens": 0},
+                            "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
                         },
                     },
                 )
@@ -1239,7 +1239,7 @@ async def gemini_stream_to_anthropic_stream(
                         "content": [],
                         "stop_reason": None,
                         "stop_sequence": None,
-                        "usage": {"input_tokens": 0, "output_tokens": 0},
+                        "usage": {"input_tokens": input_tokens, "output_tokens": output_tokens},
                     },
                 },
             )


### PR DESCRIPTION
修复 message_start 事件中 usage 硬编码为 0 的问题

问题：
- message_start 的 usage 被硬编码为 {input_tokens: 0, output_tokens: 0}
- 即使已从 usageMetadata 更新了变量值，仍使用硬编码的 0
- 不符合 Anthropic API 规范，影响客户端 token 统计显示

修复：
- 使用实际的 input_tokens 和 output_tokens 变量值
- 同时修复异常处理路径中的相同问题

影响：
- 提高与 Anthropic Streaming API 的兼容性
- 改善客户端 token 使用可见性