### PR TITLE
fix: remove thinkingLevel when thinkingBudget is set to avoid 400 error

### DIFF
--- a/src/converter/gemini_fix.py
+++ b/src/converter/gemini_fix.py
@@ -168,6 +168,7 @@ async def normalize_gemini_request(
             # 设置思考预算
             if thinking_budget:
                 thinking_config["thinkingBudget"] = thinking_budget
+                thinking_config.pop("thinkingLevel", None)  # 避免与 thinkingBudget 冲突
 
             # includeThoughts 使用配置值
             thinking_config["includeThoughts"] = return_thoughts
@@ -212,6 +213,7 @@ async def normalize_gemini_request(
                 # 优先使用传入的思考预算，否则使用默认值
                 if "thinkingBudget" not in thinking_config:
                     thinking_config["thinkingBudget"] = 1024
+                thinking_config.pop("thinkingLevel", None)  # 避免与 thinkingBudget 冲突
                 thinking_config["includeThoughts"] = return_thoughts
                 
                 # 检查最后一个 assistant 消息是否以 thinking 块开始


### PR DESCRIPTION
## 问题描述
部分客户端（如 Cherry Studio, Kelivo）会传递 `thinkingLevel` 参数，当用户使用 `-maxthinking` 后缀时会设置 `thinkingBudget`，两者同时存在会导致 Google API 返回 400 错误：

<img width="1480" height="360" alt="image" src="https://github.com/user-attachments/assets/b02225cb-6375-4201-b4e9-84dada020a3e" />

## 修改内容
在 [src/converter/gemini_fix.py](cci:7://file:///d:/ONE/CODE/gcli2api/src/converter/gemini_fix.py:0:0-0:0) 中，当设置 `thinkingBudget` 时，自动移除 `thinkingLevel`。

## 修改位置
- geminicli 模式 (Line ~171)
- antigravity 模式 (Line ~215)

## 测试
- [x] 使用 `-maxthinking` 后缀时不再报 400 错误