### PR TITLE
fix: add patternProperties/dependencies/propertyNames to _clean_schema_for_claude unsupported_keys

### DIFF
--- a/src/converter/openai2gemini.py
+++ b/src/converter/openai2gemini.py
@@ -285,6 +285,7 @@ def _clean_schema_for_claude(schema: Any, root_schema: Optional[Dict[str, Any]] 
         "const",  # const 可能导致问题
         "contentEncoding", "contentMediaType",
         "oneOf",  # oneOf 可能导致问题，用 anyOf 替代
+        "patternProperties", "dependencies", "propertyNames",  # Google API 不支持
     }
 
     for key in list(result.keys()):


### PR DESCRIPTION
## Problem

When a model name contains `claude` (e.g. `claude-opus-4-6`), tool schemas are cleaned via `_clean_schema_for_claude()` instead of `_clean_schema_for_gemini()`. However, `_clean_schema_for_claude()` was missing `patternProperties`, `dependencies`, and `propertyNames` from its `unsupported_keys` set.

This causes Google's API to reject requests with:

```
Invalid JSON payload received. Unknown name "patternProperties" at
'request.tools[0].function_declarations[3].parameters.properties[2].value': Cannot find field.
```

## Root Cause

Google's Gemini API uses a [protobuf-based schema parser](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1/Schema) that only accepts a whitelist of JSON Schema fields. `_clean_schema_for_gemini()` already filters these fields, but `_clean_schema_for_claude()` did not.

## Fix

Added `patternProperties`, `dependencies`, and `propertyNames` to the `unsupported_keys` set in `_clean_schema_for_claude()`, consistent with `_clean_schema_for_gemini()`.

## Testing

Verified with curl — requests containing `patternProperties` in nested tool schemas now return 200 instead of 400.