### PR TITLE
feat: add 'no error' filter option for error code filtering

### DIFF
--- a/front/control_panel.html
+++ b/front/control_panel.html
@@ -1775,6 +1775,7 @@
                     <label for="errorCodeFilter" style="margin-left: 20px;">错误码：</label>
                     <select id="errorCodeFilter" class="filter-select" onchange="applyStatusFilter()">
                         <option value="all">全部</option>
+                        <option value="none">无错误</option>
                         <option value="400">400</option>
                         <option value="403">403</option>
                         <option value="429">429</option>
@@ -1931,6 +1932,7 @@
                     <select id="antigravityErrorCodeFilter" class="filter-select"
                         onchange="applyAntigravityStatusFilter()">
                         <option value="all">全部</option>
+                        <option value="none">无错误</option>
                         <option value="400">400</option>
                         <option value="403">403</option>
                         <option value="429">429</option>

--- a/front/control_panel_mobile.html
+++ b/front/control_panel_mobile.html
@@ -1442,6 +1442,7 @@
                         <label for="errorCodeFilter">错误码筛选：</label>
                         <select id="errorCodeFilter" onchange="applyStatusFilter()">
                             <option value="all">全部</option>
+                            <option value="none">无错误</option>
                             <option value="400">400</option>
                             <option value="403">403</option>
                             <option value="429">429</option>
@@ -1632,6 +1633,7 @@
                         <label for="antigravityErrorCodeFilter">错误码筛选：</label>
                         <select id="antigravityErrorCodeFilter" onchange="applyAntigravityStatusFilter()">
                             <option value="all">全部</option>
+                            <option value="none">无错误</option>
                             <option value="400">400</option>
                             <option value="403">403</option>
                             <option value="429">429</option>

--- a/src/storage/mongodb_manager.py
+++ b/src/storage/mongodb_manager.py
@@ -1061,13 +1061,22 @@ class MongoDBManager:
 
             # 错误码筛选 - 兼容存储为数字或字符串的情况
             if error_code_filter and str(error_code_filter).strip().lower() != "all":
-                filter_value = str(error_code_filter).strip()
-                query_values = [filter_value]
-                try:
-                    query_values.append(int(filter_value))
-                except ValueError:
-                    pass
-                query["error_codes"] = {"$in": query_values}
+                if str(error_code_filter).strip().lower() == "none":
+                    # 筛选无错误的凭证：error_codes 为空数组、不存在、或为 null
+                    query["$or"] = [
+                        {"error_codes": {"$exists": False}},
+                        {"error_codes": None},
+                        {"error_codes": []},
+                        {"error_codes": "[]"},
+                    ]
+                else:
+                    filter_value = str(error_code_filter).strip()
+                    query_values = [filter_value]
+                    try:
+                        query_values.append(int(filter_value))
+                    except ValueError:
+                        pass
+                    query["error_codes"] = {"$in": query_values}
 
             # 计算全局统计数据（不受筛选条件影响）
             global_stats = {"total": 0, "normal": 0, "disabled": 0}

--- a/src/storage/psql_manager.py
+++ b/src/storage/psql_manager.py
@@ -674,12 +674,16 @@ class PSQLManager:
                 # 错误码筛选
                 filter_value = None
                 filter_int = None
+                filter_none = False
                 if error_code_filter and str(error_code_filter).strip().lower() != "all":
-                    filter_value = str(error_code_filter).strip()
-                    try:
-                        filter_int = int(filter_value)
-                    except ValueError:
-                        filter_int = None
+                    if str(error_code_filter).strip().lower() == "none":
+                        filter_none = True
+                    else:
+                        filter_value = str(error_code_filter).strip()
+                        try:
+                            filter_int = int(filter_value)
+                        except ValueError:
+                            filter_int = None
 
                 all_summaries = []
                 for row in all_rows:
@@ -687,6 +691,11 @@ class PSQLManager:
                     model_cooldowns = json.loads(row["model_cooldowns"] or "{}")
                     active_cooldowns = {k: v for k, v in model_cooldowns.items() if v > current_time}
                     error_codes = json.loads(error_codes_json)
+
+                    # 筛选无错误的凭证
+                    if filter_none:
+                        if error_codes:
+                            continue
 
                     if filter_value:
                         match = False

--- a/src/storage/sqlite_manager.py
+++ b/src/storage/sqlite_manager.py
@@ -896,12 +896,16 @@ class SQLiteManager:
 
                 filter_value = None
                 filter_int = None
+                filter_none = False
                 if error_code_filter and str(error_code_filter).strip().lower() != "all":
-                    filter_value = str(error_code_filter).strip()
-                    try:
-                        filter_int = int(filter_value)
-                    except ValueError:
-                        filter_int = None
+                    if str(error_code_filter).strip().lower() == "none":
+                        filter_none = True
+                    else:
+                        filter_value = str(error_code_filter).strip()
+                        try:
+                            filter_int = int(filter_value)
+                        except ValueError:
+                            filter_int = None
 
                 # 构建WHERE子句
                 where_clause = ""
@@ -947,6 +951,12 @@ class SQLiteManager:
                             }
 
                         error_codes = json.loads(error_codes_json)
+
+                        # 筛选无错误的凭证
+                        if filter_none:
+                            if error_codes:
+                                continue
+
                         if filter_value:
                             match = False
                             for code in error_codes:


### PR DESCRIPTION
## Description
Add a **'无错误' (No Error)** option to the error code filter dropdowns in the control panel, allowing users to quickly filter credentials that have no error codes.

## Changes

### Frontend
- Added <option value=none>无错误</option> to both GCLI and Antigravity error code filter dropdowns
- Applied to both desktop (control_panel.html) and mobile (control_panel_mobile.html) versions

### Backend
- **SQLite** (sqlite_manager.py): Added ilter_none flag to skip credentials with non-empty error_codes
- **PostgreSQL** (psql_manager.py): Same logic as SQLite
- **MongoDB** (mongodb_manager.py): Uses $or query to match empty/null/missing error_codes

## How it works
1. User selects '无错误' from the error code filter dropdown
2. Frontend sends error_code_filter=none to the backend API
3. Backend filters and returns only credentials with empty error_codes arrays