### PR TITLE
feat: 支持通过 size 参数自定义图片生成分辨率

### DIFF
--- a/src/converter/anthropic2gemini.py
+++ b/src/converter/anthropic2gemini.py
@@ -766,10 +766,14 @@ async def anthropic_to_gemini_request(payload: Dict[str, Any]) -> Dict[str, Any]
     
     if tools:
         gemini_request["tools"] = tools
-    
+
     # 添加 toolConfig（如果有 tool_choice）
     if tool_config:
         gemini_request["toolConfig"] = tool_config
+
+    # 透传图片生成的 size 参数（如 "1024x1536"）
+    if "size" in payload and payload["size"]:
+        gemini_request["size"] = payload["size"]
 
     return gemini_request
 

--- a/src/converter/gemini_fix.py
+++ b/src/converter/gemini_fix.py
@@ -34,42 +34,104 @@ LITE_SAFETY_SETTINGS = [
     {"category": "HARM_CATEGORY_CIVIC_INTEGRITY", "threshold": "BLOCK_NONE"},
 ]
 
+SUPPORTED_ASPECT_RATIOS = [
+    (1, 1), (2, 3), (3, 2), (3, 4), (4, 3),
+    (4, 5), (5, 4), (9, 16), (16, 9), (21, 9),
+]
+
+
+def _parse_size_to_image_config(size_str: str) -> Dict[str, str]:
+    """
+    解析用户传入的 size 参数为 Gemini imageConfig 参数
+
+    支持格式: "1024x1536", "1024*1536", "1024X1536"
+
+    Returns:
+        包含 aspectRatio 和/或 imageSize 的字典
+    """
+    import re
+
+    config = {}
+    size_str = size_str.strip()
+
+    match = re.match(r"^(\d+)\s*[xX*×]\s*(\d+)$", size_str)
+    if not match:
+        return config
+
+    width, height = int(match.group(1)), int(match.group(2))
+
+    if width <= 0 or height <= 0:
+        return config
+
+    # 计算最接近的支持宽高比
+    target_ratio = width / height
+    best_ratio = None
+    best_diff = float("inf")
+    for w, h in SUPPORTED_ASPECT_RATIOS:
+        diff = abs(target_ratio - w / h)
+        if diff < best_diff:
+            best_diff = diff
+            best_ratio = f"{w}:{h}"
+    if best_ratio:
+        config["aspectRatio"] = best_ratio
+
+    # 根据最大边长确定 imageSize（使用最接近的档位）
+    max_dim = max(width, height)
+    if max_dim <= 1280:
+        config["imageSize"] = "1K"
+    elif max_dim <= 2560:
+        config["imageSize"] = "2K"
+    else:
+        config["imageSize"] = "4K"
+
+    return config
+
+
 def prepare_image_generation_request(
     request_body: Dict[str, Any],
     model: str
 ) -> Dict[str, Any]:
     """
     图像生成模型请求体后处理
-    
+
+    支持三种方式指定图片参数（优先级从高到低）:
+    1. size 参数: 如 "1024x1536"，自动计算 aspectRatio 和 imageSize
+    2. 模型名后缀: 如 -4k, -2k, -16x9, -1x1
+    3. 默认值: 不设置额外参数
+
     Args:
         request_body: 原始请求体
         model: 模型名称
-    
+
     Returns:
         处理后的请求体
     """
     request_body = request_body.copy()
     model_lower = model.lower()
-    
-    # 解析分辨率
-    image_size = "4K" if "-4k" in model_lower else "2K" if "-2k" in model_lower else None
-    
-    # 解析比例
-    aspect_ratio = None
-    for suffix, ratio in [
-        ("-21x9", "21:9"), ("-16x9", "16:9"), ("-9x16", "9:16"),
-        ("-4x3", "4:3"), ("-3x4", "3:4"), ("-1x1", "1:1")
-    ]:
-        if suffix in model_lower:
-            aspect_ratio = ratio
-            break
-    
-    # 构建 imageConfig
-    image_config = {}
-    if aspect_ratio:
-        image_config["aspectRatio"] = aspect_ratio
-    if image_size:
-        image_config["imageSize"] = image_size
+
+    # 优先使用 size 参数
+    size_str = request_body.pop("size", None)
+    if size_str:
+        image_config = _parse_size_to_image_config(size_str)
+        log.debug(f"[IMAGE] 从 size 参数 '{size_str}' 解析: {image_config}")
+    else:
+        # 从模型名后缀解析
+        image_size = "4K" if "-4k" in model_lower else "2K" if "-2k" in model_lower else None
+
+        aspect_ratio = None
+        for suffix, ratio in [
+            ("-21x9", "21:9"), ("-16x9", "16:9"), ("-9x16", "9:16"),
+            ("-4x3", "4:3"), ("-3x4", "3:4"), ("-1x1", "1:1")
+        ]:
+            if suffix in model_lower:
+                aspect_ratio = ratio
+                break
+
+        image_config = {}
+        if aspect_ratio:
+            image_config["aspectRatio"] = aspect_ratio
+        if image_size:
+            image_config["imageSize"] = image_size
 
     request_body["model"] = "gemini-3.1-flash-image"  # 统一使用基础模型名
     request_body["generationConfig"] = {
@@ -80,7 +142,7 @@ def prepare_image_generation_request(
     # 移除不需要的字段
     for key in ("systemInstruction", "tools", "toolConfig"):
         request_body.pop(key, None)
-    
+
     return request_body
 
 

--- a/src/converter/openai2gemini.py
+++ b/src/converter/openai2gemini.py
@@ -1187,6 +1187,10 @@ async def convert_openai_to_gemini_request(openai_request: Dict[str, Any]) -> Di
     if "tool_choice" in openai_request and openai_request["tool_choice"]:
         gemini_request["toolConfig"] = convert_tool_choice_to_tool_config(openai_request["tool_choice"])
 
+    # 透传图片生成的 size 参数（如 "1024x1536"）
+    if "size" in openai_request and openai_request["size"]:
+        gemini_request["size"] = openai_request["size"]
+
     return gemini_request
 
 


### PR DESCRIPTION
## Summary / 概述

Allow users to specify image resolution via a `size` parameter (e.g. `"1024x1536"`) in the request body for Antigravity image generation models. The system automatically maps the input to the closest supported `aspectRatio` and `imageSize`.

允许用户在请求体中通过 `size` 参数（如 `"1024x1536"`）指定 Antigravity 图片生成模型的分辨率。系统自动将输入映射到最接近的 `aspectRatio` 和 `imageSize`。

## Changes / 改动

- **`src/converter/gemini_fix.py`**: Added `_parse_size_to_image_config()` to parse `size` into Gemini-compatible `imageConfig`. Modified `prepare_image_generation_request()` to prioritize `size` parameter over model name suffixes.
- **`src/converter/openai2gemini.py`**: Pass through `size` field from OpenAI request to Gemini request.
- **`src/converter/anthropic2gemini.py`**: Pass through `size` field from Anthropic request to Gemini request.

## Usage / 使用方式

```json
POST /antigravity/v1/chat/completions

{
  "model": "gemini-image",
  "messages": [{"role": "user", "content": "画一只猫"}],
  "size": "1024x1536"
}
```

Supported separator formats / 支持的分隔符格式: `1024x1536`, `1024*1536`, `1024X1536`, `1024×1536`

## Resolution Mapping / 分辨率映射

Non-standard resolutions are automatically snapped to the closest supported preset:

非标准分辨率会自动映射到最接近的预设值：

| Input | aspectRatio | imageSize |
|-------|-------------|-----------|
| `1024x1536` | 2:3 | 2K |
| `1920x1080` | 16:9 | 2K |
| `512x512` | 1:1 | 1K |
| `1088x2066` | 9:16 | 2K |
| `3000x4000` | 3:4 | 4K |

## Priority / 优先级

1. `size` parameter (highest) / `size` 参数（最高）
2. Model name suffix (`-4k`, `-16x9`, etc.) / 模型名后缀
3. Default (no config) / 默认值（不设置）

## Backward Compatibility / 向后兼容

Fully backward compatible — existing model name suffix behavior is unchanged when `size` is not provided.

完全向后兼容 — 不传 `size` 时，原有的模型名后缀行为不变。

🤖 Generated with [Claude Code](https://claude.com/claude-code)