### PR TITLE
fix(converter): 修复多轮工具调用 content 嵌套字符串扩散

### DIFF
--- a/src/converter/gemini_fix.py
+++ b/src/converter/gemini_fix.py
@@ -827,8 +827,18 @@ async def normalize_gemini_request(
                             text_value = part["text"]
                             if isinstance(text_value, list):
                                 # 如果是列表，合并为字符串
+                                # 注意: list 中的元素可能是 dict（如 {"type":"text","text":"..."}），不能直接 str(dict)
+                                # 否则会产生 Python repr 字符串 "{'type': 'text', 'text': '...'}"，污染 model 历史
                                 log.warning(f"[GEMINI_FIX] text 字段是列表，自动合并: {text_value}")
-                                part["text"] = " ".join(str(t) for t in text_value if t)
+                                text_parts = []
+                                for t in text_value:
+                                    if isinstance(t, dict) and "text" in t:
+                                        text_parts.append(str(t["text"]))
+                                    elif isinstance(t, str):
+                                        text_parts.append(t)
+                                    elif t is not None:
+                                        text_parts.append(str(t))
+                                part["text"] = " ".join(text_parts)
                             elif isinstance(text_value, str):
                                 # 清理尾随空格
                                 part["text"] = text_value.rstrip()

--- a/src/converter/openai2gemini.py
+++ b/src/converter/openai2gemini.py
@@ -1301,8 +1301,26 @@ async def convert_openai_to_gemini_request(openai_request: Dict[str, Any]) -> Di
             parts = []
 
             # 如果有文本内容,先添加文本
+            # 注意: content 可能是 str、list（OpenAI content block 格式 [{"type":"text","text":"..."}]）、dict 或 None
+            # 必须解包为纯字符串，否则 text 字段会变成 list，触发 gemini_fix 的 str(dict) 产生嵌套字符串
             if content:
-                parts.append({"text": content})
+                if isinstance(content, list):
+                    for _part in content:
+                        if isinstance(_part, dict):
+                            if _part.get("type") == "text" or "text" in _part:
+                                _t = _part.get("text", "")
+                                if _t:
+                                    parts.append({"text": _t})
+                        elif isinstance(_part, str) and _part:
+                            parts.append({"text": _part})
+                elif isinstance(content, str):
+                    parts.append({"text": content})
+                elif isinstance(content, dict):
+                    _t = content.get("text", "")
+                    if _t:
+                        parts.append({"text": _t})
+                else:
+                    parts.append({"text": str(content)})
 
             # 添加每个工具调用
             for tool_call in tool_calls:


### PR DESCRIPTION
## 问题

多轮工具调用对话中，assistant 响应 content 逐渐出现 `{'type': 'text', 'text': '...'}` 嵌套字符串，逐轮加深，最终模型回复不可读。

触发条件：客户端发送 assistant+tool_calls 消息，content 为 OpenAI 标准 list 格式 `[{"type":"text","text":"..."}]`（AstrBot 等客户端默认格式）。

## 根因

1. **请求方向不解包 list content**：`openai2gemini.py` 的 assistant+tool_calls 分支直接 `parts.append({"text": content})`，当 content 是 list 时 text 字段变 list。
2. **gemini_fix 用 str(dict) 合并 list**：`gemini_fix.py` 的 list 合并分支 `" ".join(str(t) for t in text_value)`，当元素是 dict 时产生 Python repr 字符串。

两者协同：text 字段变 list -> gemini_fix 用 str(dict) 产生嵌套字符串 -> 嵌套字符串进入 model 历史 -> Gemini 模仿返回嵌套格式 -> 客户端存下再发回 -> 逐轮加深。

## 改动

### `src/converter/openai2gemini.py`

`convert_openai_to_gemini_request` 函数 assistant+tool_calls 分支，将：

```python
if content:
    parts.append({"text": content})
```

改为按 content 类型分别处理：list 遍历提取 text、str 直接加入、dict 提取 text、其他 str() 兜底。与同文件普通 content 分支已有的解包逻辑对齐。

### `src/converter/gemini_fix.py`

text 字段 list 合并分支，将：

```python
part["text"] = " ".join(str(t) for t in text_value if t)
```

改为遍历 list 元素：dict 提取 text 字段值、str 直接加入、其他 str() 兜底。避免 `str(dict)` 产生 Python repr。

## 验证

修复后通过在请求/响应转换的关键位置临时加调试日志验证（4 个数据流关键点）：
- 点 A（请求入口，看客户端发来的 content 类型）：多轮后 content 仍为干净 list，不出现嵌套
- 点 B（请求转换后，看 gcli2api 转成的 text 字段）：text 字段全部为 str（修复前为 list）
- 点 C（上游原始返回，看 antigravity 返回的 text）：干净文本
- 点 D（响应转换后，看返回客户端的 delta）：干净文本
- `[GEMINI_FIX] text 字段是列表` WARNING 不再出现

## 影响评估

- content 为 str 的场景：行为不变
- content 为 list/dict 的场景：从"错误塞入"变为"正确提取"，格式更符合 Gemini API 规范
- 无工具调用的普通对话：不触发改动函数，无影响
- 对所有上游（antigravity/geminicli/vertex）兼容性：改善（parts[].text 为 string 是 Gemini API 规范要求）
- 对 Anthropic 接口：无影响（不触发改动代码路径）