### PR TITLE
Fix Antigravity Claude tool schema

### DIFF
--- a/src/converter/gemini_fix.py
+++ b/src/converter/gemini_fix.py
@@ -298,13 +298,9 @@ def _ensure_empty_tool_schema_for_claude(tools: Any, model_name: str, mode: str 
     is_claude = "claude" in (model_name or "").lower()
 
     if is_claude:
-        # antigravity 通道的 Claude 模型内部会把
-        # functionDeclarations 转换回 Anthropic 原生的 custom.input_schema，
-        # 但只有使用 parametersJsonSchema 字段时该转换才能正确带上 schema；
-        # 使用 parameters 字段会导致转换后 input_schema 缺失，报
-        # "tools.0.custom.input_schema: Field required" 错误。
-        # geminicli 则需要使用 parameters 字段。
-        schema_field = "parametersJsonSchema" if mode == "antigravity" else "parameters"
+        # Antigravity 外层 API 只接受 functionDeclarations。
+        # Claude 模型会把 parameters 转为 custom.input_schema；使用
+        # parametersJsonSchema 会使内部转换遗漏该字段并被上游拒绝。
 
         normalized_tools = []
         for tool in tools:
@@ -340,7 +336,7 @@ def _ensure_empty_tool_schema_for_claude(tools: Any, model_name: str, mode: str 
                 "functionDeclarations": [{
                     "name": name,
                     "description": description,
-                    schema_field: schema
+                    "parameters": schema
                 }]
             })
 

--- a/tests/test_gemini_fix.py
+++ b/tests/test_gemini_fix.py
@@ -1,0 +1,24 @@
+from src.converter.gemini_fix import _ensure_empty_tool_schema_for_claude
+
+
+def test_antigravity_claude_tools_keep_schema_in_parameters():
+    tools = [
+        {
+            "functionDeclarations": [
+                {
+                    "name": "test_tool",
+                    "description": "A test tool.",
+                    "parametersJsonSchema": {
+                        "type": "object",
+                        "properties": {"value": {"type": "string"}},
+                    },
+                }
+            ]
+        }
+    ]
+
+    result = _ensure_empty_tool_schema_for_claude(tools, "claude-opus-4-6-thinking", "antigravity")
+    declaration = result[0]["functionDeclarations"][0]
+
+    assert declaration["parameters"]["type"] == "object"
+    assert "parametersJsonSchema" not in declaration


### PR DESCRIPTION
## Summary
- keep Claude tool schemas in `functionDeclarations.parameters` for the Antigravity route
- add a regression test for the Claude Opus tool-schema conversion

## Reproduction
Claude Code requests through `/antigravity/v1/messages` failed with:

```
tools.0.custom.input_schema: Field required
```

`parametersJsonSchema` is accepted by the outer request format but is not propagated by the Claude model's internal conversion. Using `parameters` preserves the schema.

## Validation
- `python -m pytest tests/test_gemini_fix.py -v`
- `python -m py_compile src/converter/gemini_fix.py`
- manual local Claude Code request to `claude-opus-4-6` through the Antigravity endpoint returned HTTP 200