### PR TITLE
fix: restore Antigravity Gemini 3.1 Pro mapping and Gemini 3 thinking output

### DIFF
--- a/src/converter/antigravity_fix.py
+++ b/src/converter/antigravity_fix.py
@@ -598,10 +598,17 @@ def _normalize_antigravity_request(
 
     # 针对 Gemini 模型：根据思考设置映射至真实的 Antigravity 后端模型 ID
     if "gemini" in model.lower():
+        original_model = model
+
+        # 兼容旧的客户端别名：Antigravity 后端的 Gemini 3.1 Pro High
+        # 实际使用 gemini-pro-agent 作为模型 ID。
+        if model.lower() == "gemini-3.1-pro-high":
+            model = "gemini-pro-agent"
+            log.debug(f"[ANTIGRAVITY] 映射模型: {original_model} -> {model}")
 
         # 既然 Antigravity 后端是通过模型名来确定思考深度的，
         # 对于 Gemini 3/3.5 模型必须移除 thinkingConfig 以防止 API 返回参数冲突错误。
-        if "gemini-3" in model:
+        if "gemini-3" in original_model.lower():
             generation_config.pop("thinkingConfig", None)
         else:
             # 对于 Gemini 2.5 系列，保留 thinkingConfig

--- a/src/converter/antigravity_fix.py
+++ b/src/converter/antigravity_fix.py
@@ -606,10 +606,14 @@ def _normalize_antigravity_request(
             model = "gemini-pro-agent"
             log.debug(f"[ANTIGRAVITY] 映射模型: {original_model} -> {model}")
 
-        # 既然 Antigravity 后端是通过模型名来确定思考深度的，
-        # 对于 Gemini 3/3.5 模型必须移除 thinkingConfig 以防止 API 返回参数冲突错误。
+        # Antigravity uses the Gemini 3.x model route/name to select thinking depth.
+        # Do not send thinkingLevel/thinkingBudget because they can conflict with that route.
+        # Keep includeThoughts so reasoning is still returned to the frontend when enabled.
         if "gemini-3" in original_model.lower():
-            generation_config.pop("thinkingConfig", None)
+            thinking_config = generation_config.setdefault("thinkingConfig", {})
+            thinking_config.pop("thinkingBudget", None)
+            thinking_config.pop("thinkingLevel", None)
+            thinking_config["includeThoughts"] = return_thoughts
         else:
             # 对于 Gemini 2.5 系列，保留 thinkingConfig
             if thinking:


### PR DESCRIPTION
Fixes #397. Related to #385 and #394.

This PR restores two pieces of Antigravity compatibility that were lost during the converter refactor.

### 1. Restore Gemini 3.1 Pro High backend mapping

```text
gemini-3.1-pro-high -> gemini-pro-agent
```

The older Antigravity normalization explicitly treated `gemini-3.1-pro-high` as a deprecated client-facing alias and mapped it to the backend model ID `gemini-pro-agent`. After commit `e4312ae71ecfb1b58ec78ddc5a95d6abef39f898`, the dedicated Antigravity refactor removed `map_antigravity_gemini_model()` and the new `antigravity_fix.py` no longer performed that mapping, so the alias was sent upstream unchanged and could return `400 INVALID_ARGUMENT`.

### 2. Preserve `includeThoughts` for Gemini 3.x

Current code removes the entire `thinkingConfig` for Gemini 3.x in order to avoid sending `thinkingLevel` / `thinkingBudget` when Antigravity already selects thinking depth by model route/name. That also removes `includeThoughts`, so upstream no longer returns thought parts and OpenAI-compatible clients receive no `reasoning_content`.

The updated logic keeps only the output toggle:

```python
thinking_config = generation_config.setdefault("thinkingConfig", {})
thinking_config.pop("thinkingBudget", None)
thinking_config.pop("thinkingLevel", None)
thinking_config["includeThoughts"] = return_thoughts
```

This keeps model-route-based thinking depth while allowing reasoning to be returned to the frontend. It applies to Gemini 3.x models such as `gemini-3.1-pro-*` and `gemini-3.7-flash` without reintroducing thinking level/budget conflicts.

The change remains scoped to `src/converter/antigravity_fix.py`; it does not modify Claude routing, headers, auth, request IDs, or Gemini 2.5 handling.

Fork commits:
- `20ebcfa9b1724c0cd32da44563c3edbedbea36d7` — restore 3.1 Pro High mapping
- `a4cdb809c2354b723d2dad6730b44d4aab3a57e7` — preserve Gemini 3 thinking output