### PR TITLE
feat(audio): add OpenAI-compatible /v1/audio/transcriptions endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -155,6 +155,12 @@ LOG_FILE=log.txt
 # 默认: 3
 ANTI_TRUNCATION_MAX_ATTEMPTS=3
 
+# 音频转录使用的 Gemini 模型
+# 当客户端调用 /v1/audio/transcriptions 时不传 model，
+# 或传入 whisper-1 / gpt-4o-transcribe 等 OpenAI 模型名时使用该模型
+# 默认: gemini-2.5-flash
+AUDIO_TRANSCRIPTION_MODEL=gemini-2.5-flash
+
 # ================================================================
 # 环境变量使用说明
 # ================================================================

--- a/README.md
+++ b/README.md
@@ -158,6 +158,21 @@ ghcr.io/su-kaka/gcli2api:latest
   - Claude 格式端点：`/antigravity/v1/messages`
   - 支持所有 Antigravity 模型（Claude、Gemini 等）
   - 自动模型名称映射和思维模式检测
+- **音频转录端点**：`/v1/audio/transcriptions` 和 `/antigravity/v1/audio/transcriptions`
+  - 兼容 OpenAI Whisper 接口（`multipart/form-data`），可直接对接 OpenAI SDK
+  - 表单字段：`file`（必填）、`model`、`prompt`、`language`、`response_format`、`temperature`
+  - 支持的音频格式：mp3、wav、m4a/aac、ogg/opus、flac、aiff（Gemini 内联音频限制，单文件最大 15MB）
+  - `response_format` 支持 `json`（默认）和 `text`；`verbose_json`/`srt`/`vtt` 需要时间戳，暂不支持
+  - 客户端传入 `whisper-1`、`gpt-4o-transcribe` 等 OpenAI 模型名或不传 `model` 时，
+    自动改用 `AUDIO_TRANSCRIPTION_MODEL` 指定的 Gemini 模型（默认 `gemini-2.5-flash`）
+
+```bash
+curl -X POST "http://127.0.0.1:7861/antigravity/v1/audio/transcriptions" \
+  -H "Authorization: Bearer $API_PASSWORD" \
+  -F "file=@speech.mp3" \
+  -F "model=gemini-2.5-flash"
+# {"text":"..."}
+```
 
 ### 🔐 认证和安全管理
 

--- a/config.py
+++ b/config.py
@@ -47,6 +47,7 @@ ENV_MAPPINGS = {
     "PASSWORD": "password",
     "KEEPALIVE_URL": "keepalive_url",
     "KEEPALIVE_INTERVAL": "keepalive_interval",
+    "AUDIO_TRANSCRIPTION_MODEL": "audio_transcription_model",
 }
 
 
@@ -284,6 +285,24 @@ async def get_credentials_dir() -> str:
     Default: ./creds
     """
     return str(await get_config_value("credentials_dir", "./creds", "CREDENTIALS_DIR"))
+
+
+async def get_audio_transcription_model() -> str:
+    """
+    Get the Gemini model used by /v1/audio/transcriptions.
+
+    Applies when the client omits `model` or sends an OpenAI transcription model
+    name (whisper-1, gpt-4o-transcribe, ...), so unmodified OpenAI SDK clients work.
+
+    Environment variable: AUDIO_TRANSCRIPTION_MODEL
+    Database config key: audio_transcription_model
+    Default: gemini-2.5-flash
+    """
+    return str(
+        await get_config_value(
+            "audio_transcription_model", "gemini-2.5-flash", "AUDIO_TRANSCRIPTION_MODEL"
+        )
+    )
 
 
 async def get_code_assist_endpoint() -> str:

--- a/src/converter/audio.py
+++ b/src/converter/audio.py
@@ -1,0 +1,197 @@
+"""
+Audio Converter - OpenAI 音频接口与 Gemini inlineData 之间的转换
+
+提供音频 MIME 检测、大小校验、请求构建和转录文本提取等纯函数，
+供各后端的 /v1/audio/transcriptions 路由复用。
+"""
+
+import base64
+from typing import Any, Dict, Optional
+
+# Gemini 支持的音频 MIME 类型
+# 参考: https://ai.google.dev/gemini-api/docs/audio
+# 注意: webm / mp4 等容器格式不在支持列表内，需要客户端自行转码
+EXTENSION_MIME_TYPES: Dict[str, str] = {
+    "mp3": "audio/mp3",
+    "mpeg": "audio/mp3",
+    "mpga": "audio/mp3",
+    "wav": "audio/wav",
+    "wave": "audio/wav",
+    "m4a": "audio/aac",
+    "aac": "audio/aac",
+    "ogg": "audio/ogg",
+    "oga": "audio/ogg",
+    "opus": "audio/ogg",
+    "flac": "audio/flac",
+    "aiff": "audio/aiff",
+    "aif": "audio/aiff",
+}
+
+# 支持的 MIME 类型集合（用于校验客户端传来的 Content-Type）
+SUPPORTED_MIME_TYPES = frozenset(EXTENSION_MIME_TYPES.values())
+
+# 单次内联音频的大小上限。Gemini 内联请求体上限为 20MB，
+# 留出 base64 膨胀和其他字段的余量后取 15MB（约 16 分钟 MP3）。
+MAX_INLINE_AUDIO_BYTES = 15 * 1024 * 1024
+
+# 未显式提供 prompt 时使用的默认转录指令
+DEFAULT_TRANSCRIPTION_PROMPT = "Generate a transcript of the speech."
+
+
+def normalize_audio_mime(fmt: Optional[str]) -> Optional[str]:
+    """
+    将 OpenAI 风格的音频格式标识归一化为 Gemini 需要的 MIME 类型。
+
+    接受 "wav" / "audio/wav" / "audio/x-wav" / "audio/mpeg" 等写法。
+
+    Args:
+        fmt: 格式标识或 MIME 类型
+
+    Returns:
+        归一化后的 MIME 类型，无法识别时返回 None
+    """
+    if not fmt:
+        return None
+
+    bare = fmt.split(";")[0].strip().lower()
+    if bare.startswith("audio/"):
+        bare = bare[len("audio/"):]
+    # 去掉 x- / vnd. 之类的厂商前缀
+    for prefix in ("x-", "vnd."):
+        if bare.startswith(prefix):
+            bare = bare[len(prefix):]
+
+    return EXTENSION_MIME_TYPES.get(bare)
+
+
+def detect_audio_mime_type(
+    filename: Optional[str],
+    content_type: Optional[str] = None,
+) -> str:
+    """
+    检测音频 MIME 类型，优先使用文件扩展名，其次使用客户端声明的 Content-Type。
+
+    Args:
+        filename: 上传的文件名
+        content_type: multipart 中客户端声明的 Content-Type
+
+    Returns:
+        Gemini 可接受的 MIME 类型
+
+    Raises:
+        ValueError: 无法识别或不受支持的音频格式
+    """
+    if filename and "." in filename:
+        extension = filename.rsplit(".", 1)[-1]
+        mime_type = normalize_audio_mime(extension)
+        if mime_type:
+            return mime_type
+
+    mime_type = normalize_audio_mime(content_type)
+    if mime_type:
+        return mime_type
+
+    supported = ", ".join(sorted(set(EXTENSION_MIME_TYPES)))
+    raise ValueError(
+        f"Unsupported audio format: {filename or content_type or 'unknown'}. "
+        f"Supported formats: {supported}"
+    )
+
+
+def exceeds_size_limit(size_bytes: int) -> bool:
+    """判断音频是否超过内联大小上限"""
+    return size_bytes > MAX_INLINE_AUDIO_BYTES
+
+
+def encode_to_base64(audio_data: bytes) -> str:
+    """将音频字节编码为 base64 字符串"""
+    return base64.b64encode(audio_data).decode("ascii")
+
+
+def build_transcription_request(
+    audio_base64: str,
+    mime_type: str,
+    prompt: Optional[str] = None,
+    language: Optional[str] = None,
+    temperature: Optional[float] = None,
+) -> Dict[str, Any]:
+    """
+    构建 Gemini generateContent 请求体（不含 model 字段）。
+
+    Args:
+        audio_base64: base64 编码后的音频数据
+        mime_type: 音频 MIME 类型
+        prompt: 转录指令，为空时使用默认指令
+        language: ISO-639-1 语言代码，作为提示传给模型
+        temperature: 采样温度
+
+    Returns:
+        Gemini 格式的请求体
+    """
+    instruction = (prompt or "").strip() or DEFAULT_TRANSCRIPTION_PROMPT
+    if language:
+        instruction = (
+            f"{instruction}\n"
+            f"The audio is in language '{language}'. "
+            f"Return only the transcript text, without commentary or timestamps."
+        )
+
+    request: Dict[str, Any] = {
+        "contents": [
+            {
+                "role": "user",
+                "parts": [
+                    {"text": instruction},
+                    {"inlineData": {"mimeType": mime_type, "data": audio_base64}},
+                ],
+            }
+        ]
+    }
+
+    if temperature is not None:
+        request["generationConfig"] = {"temperature": temperature}
+
+    return request
+
+
+def extract_transcription_text(payload: Dict[str, Any]) -> str:
+    """
+    从 Gemini 响应中提取转录文本。
+
+    兼容 v1internal 的 {"response": {...}} 包装格式，并跳过思考内容。
+
+    Args:
+        payload: 解析后的 Gemini 响应体
+
+    Returns:
+        拼接后的转录文本，提取失败时返回空字符串
+    """
+    if not isinstance(payload, dict):
+        return ""
+
+    # 处理 v1internal 的 response 包装格式
+    inner = payload.get("response")
+    if isinstance(inner, dict):
+        payload = inner
+
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        return ""
+
+    first = candidates[0]
+    if not isinstance(first, dict):
+        return ""
+
+    parts = (first.get("content") or {}).get("parts")
+    if not isinstance(parts, list):
+        return ""
+
+    texts = [
+        part["text"]
+        for part in parts
+        if isinstance(part, dict)
+        and isinstance(part.get("text"), str)
+        and not part.get("thought", False)
+    ]
+
+    return "".join(texts).strip()

--- a/src/router/antigravity/audio.py
+++ b/src/router/antigravity/audio.py
@@ -1,0 +1,8 @@
+"""
+Antigravity Audio Router - OpenAI 格式的音频转录接口
+POST /antigravity/v1/audio/transcriptions
+"""
+
+from src.router.audio_common import build_audio_router
+
+router = build_audio_router("/antigravity/v1/audio/transcriptions", backend="antigravity")

--- a/src/router/audio_common.py
+++ b/src/router/audio_common.py
@@ -1,0 +1,207 @@
+"""
+Audio Router Factory - 共用的 OpenAI 音频转录路由
+
+各后端 (geminicli / antigravity) 通过 build_audio_router 生成
+互相独立但行为一致的 /v1/audio/transcriptions 路由。
+
+音频以 inlineData 的形式随 generateContent 一起发送，
+凭证轮换、重试和错误处理全部复用各后端已有的 non_stream_request。
+"""
+
+import importlib
+import json
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Depends, File, Form, UploadFile
+from fastapi.responses import JSONResponse, PlainTextResponse, Response
+
+from config import get_audio_transcription_model
+from log import log
+from src.converter.audio import (
+    build_transcription_request,
+    detect_audio_mime_type,
+    encode_to_base64,
+    exceeds_size_limit,
+    extract_transcription_text,
+    MAX_INLINE_AUDIO_BYTES,
+)
+from src.utils import authenticate_bearer, get_base_model_from_feature_model
+
+# 支持的后端及其 API 模块
+BACKEND_API_MODULES = {
+    "geminicli": "src.api.geminicli",
+    "antigravity": "src.api.antigravity",
+}
+
+# 客户端常用的 OpenAI 转录模型名，收到这些名字时改用配置中的 Gemini 模型，
+# 这样未经改造的 OpenAI SDK 也能直接指向本服务。
+OPENAI_TRANSCRIPTION_MODELS = frozenset(
+    {
+        "whisper",
+        "whisper-1",
+        "whisper-large-v3",
+        "gpt-4o-transcribe",
+        "gpt-4o-mini-transcribe",
+    }
+)
+
+# 需要时间戳的响应格式，当前实现不返回分段信息
+UNSUPPORTED_RESPONSE_FORMATS = frozenset({"verbose_json", "srt", "vtt"})
+
+
+def _error_response(status_code: int, message: str, error_type: str) -> JSONResponse:
+    """构建 OpenAI 风格的错误响应"""
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": {"message": message, "type": error_type, "code": None}},
+    )
+
+
+async def _resolve_model(requested_model: Optional[str]) -> str:
+    """将客户端请求的模型名解析为实际调用的 Gemini 模型名"""
+    base_model = get_base_model_from_feature_model((requested_model or "").strip())
+
+    if not base_model or base_model.lower() in OPENAI_TRANSCRIPTION_MODELS:
+        return await get_audio_transcription_model()
+
+    return base_model
+
+
+def _parse_response_body(response: Response) -> Dict[str, Any]:
+    """从后端返回的 Response 对象中解析 JSON 响应体"""
+    body = getattr(response, "body", None)
+    if body is None:
+        body = getattr(response, "content", b"")
+    if isinstance(body, bytes):
+        body = body.decode("utf-8", errors="replace")
+
+    return json.loads(body)
+
+
+def build_audio_router(path: str, backend: str) -> APIRouter:
+    """
+    构建某个后端的音频转录路由
+
+    Args:
+        path: 路由路径，例如 "/v1/audio/transcriptions"
+        backend: 后端名称，必须是 BACKEND_API_MODULES 中的键
+
+    Returns:
+        已注册转录路由的 APIRouter
+    """
+    if backend not in BACKEND_API_MODULES:
+        raise ValueError(f"Unknown audio backend: {backend}")
+
+    router = APIRouter()
+    log_prefix = f"[{backend.upper()}-AUDIO]"
+
+    @router.post(path)
+    async def create_transcription(
+        file: UploadFile = File(...),
+        model: str = Form(default=""),
+        prompt: str = Form(default=""),
+        language: Optional[str] = Form(default=None),
+        response_format: str = Form(default="json"),
+        temperature: Optional[float] = Form(default=None),
+        token: str = Depends(authenticate_bearer),
+    ):
+        """处理 OpenAI 格式的音频转录请求 (multipart/form-data)"""
+        response_format = (response_format or "json").strip().lower()
+        if response_format in UNSUPPORTED_RESPONSE_FORMATS:
+            return _error_response(
+                400,
+                f"response_format '{response_format}' is not supported; "
+                f"use 'json' or 'text'.",
+                "invalid_request_error",
+            )
+        if response_format not in ("json", "text"):
+            return _error_response(
+                400,
+                f"Unknown response_format '{response_format}'; use 'json' or 'text'.",
+                "invalid_request_error",
+            )
+
+        # 1. 解析音频格式
+        try:
+            mime_type = detect_audio_mime_type(file.filename, file.content_type)
+        except ValueError as e:
+            return _error_response(400, str(e), "invalid_request_error")
+
+        # 2. 读取并校验大小
+        audio_bytes = await file.read()
+        if not audio_bytes:
+            return _error_response(
+                400, "Uploaded audio file is empty.", "invalid_request_error"
+            )
+
+        if exceeds_size_limit(len(audio_bytes)):
+            limit_mb = MAX_INLINE_AUDIO_BYTES // (1024 * 1024)
+            return _error_response(
+                413,
+                f"Audio file too large ({len(audio_bytes)} bytes). "
+                f"The inline upload limit is {limit_mb} MB "
+                f"(roughly 16 minutes of MP3); compress or split the file.",
+                "invalid_request_error",
+            )
+
+        # 3. 构建 Gemini 请求
+        real_model = await _resolve_model(model)
+        log.info(
+            f"{log_prefix} transcription: file={file.filename}, "
+            f"size={len(audio_bytes)} bytes, mime={mime_type}, model={real_model}"
+        )
+
+        api_request = {
+            "model": real_model,
+            "request": build_transcription_request(
+                audio_base64=encode_to_base64(audio_bytes),
+                mime_type=mime_type,
+                prompt=prompt,
+                language=language,
+                temperature=temperature,
+            ),
+        }
+
+        # 4. 调用后端 (凭证轮换和重试由 non_stream_request 负责)
+        module = importlib.import_module(BACKEND_API_MODULES[backend])
+        response = await module.non_stream_request(body=api_request)
+
+        # 5. 解析响应
+        # 重建响应而不是直接转发后端的 Response，避免把上游的
+        # Content-Encoding / Content-Length 等响应头带到已解码的响应体上
+        status_code = getattr(response, "status_code", 200)
+        upstream_failed = not 200 <= status_code < 300
+
+        try:
+            payload = _parse_response_body(response)
+        except Exception as e:
+            log.error(f"{log_prefix} failed to parse upstream response: {e}")
+            if upstream_failed:
+                return _error_response(
+                    status_code,
+                    f"Upstream returned status {status_code}.",
+                    "api_error",
+                )
+            return _error_response(
+                502, f"Failed to parse upstream response: {e}", "api_error"
+            )
+
+        if upstream_failed or "error" in payload:
+            log.error(
+                f"{log_prefix} upstream error (status={status_code}): "
+                f"{json.dumps(payload, ensure_ascii=False)[:500]}"
+            )
+            return JSONResponse(
+                status_code=status_code if upstream_failed else 502, content=payload
+            )
+
+        # 6. 提取转录文本
+        text = extract_transcription_text(payload)
+        log.info(f"{log_prefix} transcription completed, {len(text)} characters")
+
+        if response_format == "text":
+            return PlainTextResponse(content=text)
+
+        return JSONResponse(content={"text": text})
+
+    return router

--- a/src/router/geminicli/audio.py
+++ b/src/router/geminicli/audio.py
@@ -1,0 +1,8 @@
+"""
+Gemini CLI Audio Router - OpenAI 格式的音频转录接口
+POST /v1/audio/transcriptions
+"""
+
+from src.router.audio_common import build_audio_router
+
+router = build_audio_router("/v1/audio/transcriptions", backend="geminicli")

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,0 +1,109 @@
+import base64
+
+import pytest
+
+from src.converter.audio import (
+    build_transcription_request,
+    detect_audio_mime_type,
+    encode_to_base64,
+    exceeds_size_limit,
+    extract_transcription_text,
+    normalize_audio_mime,
+    MAX_INLINE_AUDIO_BYTES,
+)
+
+
+def test_normalize_audio_mime_accepts_bare_and_prefixed_forms():
+    assert normalize_audio_mime("wav") == "audio/wav"
+    assert normalize_audio_mime("audio/wav") == "audio/wav"
+    assert normalize_audio_mime("audio/x-wav") == "audio/wav"
+    assert normalize_audio_mime("audio/mpeg") == "audio/mp3"
+    assert normalize_audio_mime("m4a") == "audio/aac"
+    assert normalize_audio_mime("audio/wav; codecs=1") == "audio/wav"
+    assert normalize_audio_mime("video/mp4") is None
+    assert normalize_audio_mime(None) is None
+
+
+def test_detect_mime_type_prefers_extension():
+    assert detect_audio_mime_type("speech.MP3") == "audio/mp3"
+    # 扩展名可识别时，忽略浏览器给出的通用 Content-Type
+    assert detect_audio_mime_type("speech.flac", "application/octet-stream") == "audio/flac"
+
+
+def test_detect_mime_type_falls_back_to_content_type():
+    assert detect_audio_mime_type("blob", "audio/ogg") == "audio/ogg"
+    assert detect_audio_mime_type(None, "audio/wav") == "audio/wav"
+
+
+def test_detect_mime_type_rejects_unsupported_format():
+    # webm 不在 Gemini 支持的音频格式内，必须显式报错而不是猜一个 MIME
+    with pytest.raises(ValueError) as excinfo:
+        detect_audio_mime_type("recording.webm", "audio/webm")
+    assert "Unsupported audio format" in str(excinfo.value)
+
+
+def test_size_limit_boundary():
+    assert not exceeds_size_limit(MAX_INLINE_AUDIO_BYTES)
+    assert exceeds_size_limit(MAX_INLINE_AUDIO_BYTES + 1)
+
+
+def test_build_transcription_request_shape():
+    payload = build_transcription_request(
+        audio_base64=encode_to_base64(b"fake audio"),
+        mime_type="audio/wav",
+    )
+
+    parts = payload["contents"][0]["parts"]
+    assert parts[0]["text"] == "Generate a transcript of the speech."
+    assert parts[1]["inlineData"]["mimeType"] == "audio/wav"
+    assert base64.b64decode(parts[1]["inlineData"]["data"]) == b"fake audio"
+    # 未指定 temperature 时不应写入 generationConfig
+    assert "generationConfig" not in payload
+
+
+def test_build_transcription_request_honours_prompt_language_and_temperature():
+    payload = build_transcription_request(
+        audio_base64="QUJD",
+        mime_type="audio/mp3",
+        prompt="Transcribe verbatim.",
+        language="es",
+        temperature=0.2,
+    )
+
+    instruction = payload["contents"][0]["parts"][0]["text"]
+    assert instruction.startswith("Transcribe verbatim.")
+    assert "'es'" in instruction
+    assert payload["generationConfig"]["temperature"] == 0.2
+
+
+def test_extract_text_unwraps_v1internal_envelope_and_skips_thoughts():
+    response = {
+        "response": {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"text": "internal reasoning", "thought": True},
+                            {"text": "  Hello "},
+                            {"text": "world.  "},
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+
+    assert extract_transcription_text(response) == "Hello world."
+
+
+def test_extract_text_handles_unwrapped_and_malformed_responses():
+    assert (
+        extract_transcription_text(
+            {"candidates": [{"content": {"parts": [{"text": "plain"}]}}]}
+        )
+        == "plain"
+    )
+    assert extract_transcription_text({}) == ""
+    assert extract_transcription_text({"candidates": []}) == ""
+    assert extract_transcription_text({"candidates": [{"content": {}}]}) == ""
+    assert extract_transcription_text(None) == ""

--- a/web.py
+++ b/web.py
@@ -24,10 +24,12 @@ from src.router.antigravity.openai import router as antigravity_openai_router
 from src.router.antigravity.gemini import router as antigravity_gemini_router
 from src.router.antigravity.anthropic import router as antigravity_anthropic_router
 from src.router.antigravity.model_list import router as antigravity_model_list_router
+from src.router.antigravity.audio import router as antigravity_audio_router
 from src.router.geminicli.openai import router as geminicli_openai_router
 from src.router.geminicli.gemini import router as geminicli_gemini_router
 from src.router.geminicli.anthropic import router as geminicli_anthropic_router
 from src.router.geminicli.model_list import router as geminicli_model_list_router
+from src.router.geminicli.audio import router as geminicli_audio_router
 from src.task_manager import shutdown_all_tasks
 from src.panel import router as panel_router
 from src.keeplive import keepalive_service
@@ -202,6 +204,9 @@ app.include_router(geminicli_gemini_router, prefix="", tags=["Geminicli Gemini A
 # Geminicli模型列表路由 - 处理Gemini格式的模型列表请求
 app.include_router(geminicli_model_list_router, prefix="", tags=["Geminicli Model List"])
 
+# Geminicli音频转录路由 - OpenAI 格式的语音转文字接口
+app.include_router(geminicli_audio_router, prefix="", tags=["Geminicli Audio API"])
+
 # Antigravity路由 - 处理OpenAI格式请求并转换为Antigravity API
 app.include_router(antigravity_openai_router, prefix="", tags=["Antigravity OpenAI API"])
 
@@ -210,6 +215,9 @@ app.include_router(antigravity_gemini_router, prefix="", tags=["Antigravity Gemi
 
 # Antigravity模型列表路由 - 处理Gemini格式的模型列表请求
 app.include_router(antigravity_model_list_router, prefix="", tags=["Antigravity Model List"])
+
+# Antigravity音频转录路由 - OpenAI 格式的语音转文字接口
+app.include_router(antigravity_audio_router, prefix="", tags=["Antigravity Audio API"])
 
 # Antigravity Anthropic Messages 路由 - Anthropic Messages 格式兼容
 app.include_router(antigravity_anthropic_router, prefix="", tags=["Antigravity Anthropic Messages"])


### PR DESCRIPTION
## What

Adds a Whisper-compatible speech-to-text endpoint on both channels:

| Method | Path | Backend |
|---|---|---|
| `POST` | `/v1/audio/transcriptions` | geminicli |
| `POST` | `/antigravity/v1/audio/transcriptions` | antigravity |

The uploaded file is turned into a Gemini `inlineData` part alongside a text prompt, and the request is handed to each backend's existing `non_stream_request` — so credential rotation, retries, auto-ban and error handling are inherited rather than reimplemented. The endpoint adds no new dependency (`python-multipart` is already required).

This ports the behaviour of [`Antigravity-Manager`'s `handlers/audio.rs`](https://github.com/lbjlaq/Antigravity-Manager/blob/main/src-tauri/src/proxy/handlers/audio.rs) to this project.

## API

`multipart/form-data` fields, matching OpenAI's transcription API:

- `file` (required)
- `model`, `prompt`, `language`, `response_format`, `temperature`

`response_format` supports `json` (default) and `text`. `verbose_json` / `srt` / `vtt` need per-segment timestamps, so they are rejected with a clear `400` instead of silently returning the wrong shape.

MIME type is resolved from the filename extension first and the declared `Content-Type` second, restricted to the formats Gemini documents (mp3, wav, m4a/aac, ogg/opus, flac, aiff). Unsupported containers such as `webm` fail with a message listing what is accepted. Inline uploads are capped at 15 MB, below the 20 MB request-body limit.

### OpenAI SDK compatibility

Clients that send an OpenAI transcription model name (`whisper-1`, `gpt-4o-transcribe`, …) or omit `model` fall back to `AUDIO_TRANSCRIPTION_MODEL` (default `gemini-2.5-flash`), so an unmodified OpenAI SDK can be pointed at this service:

```python
client = OpenAI(base_url="http://127.0.0.1:7861/antigravity/v1", api_key=API_PASSWORD)
client.audio.transcriptions.create(model="whisper-1", file=open("speech.mp3", "rb"))
```

## Structure

- `src/converter/audio.py` — pure helpers (MIME detection, size guard, request building, text extraction)
- `src/router/audio_common.py` — shared FastAPI handler, one router per backend via `build_audio_router()`
- `src/router/{geminicli,antigravity}/audio.py` — 3-line backend bindings
- `config.py` — `AUDIO_TRANSCRIPTION_MODEL` / `audio_transcription_model`

Text extraction unwraps the `v1internal` `{"response": {...}}` envelope, joins all text parts and skips parts flagged `thought`, so thinking models do not leak reasoning into the transcript.

## Testing

`tests/test_audio.py` — 9 unit tests over the pure helpers (MIME normalisation and fallback, unsupported-format rejection, size boundary, request shape, envelope unwrapping, malformed responses). All pass.

Verified live against the antigravity channel with a 6.4 s synthesised speech sample:

```
$ curl -s -X POST .../antigravity/v1/audio/transcriptions \
    -H "Authorization: Bearer ***" -F file=@speech.wav
{"text":"The quick brown fox jumps over the lazy dog. Gemini audio transcription test number 42."}
```

Also confirmed end to end:

- `whisper-1` + `response_format=text` → `200 text/plain` with the transcript
- filename without an extension → falls back to `Content-Type` → `200`
- unsupported `webm` → `400`, oversized file → `413`, empty file → `400`, `srt` → `400`, missing auth → `401`
- unknown model → upstream `404` body forwarded with its status
- works with `gemini-2.5-flash`, `gemini-3.5-flash-low`, `gemini-3.6-flash-medium`, `gemini-3.7-flash-tiered`

The geminicli channel returned `403 SUBSCRIPTION_REQUIRED` on my account, but `/v1/chat/completions` returns the same `403` there, so that is a credential-licensing condition rather than anything specific to this endpoint — the code path is identical to the antigravity one that passes.

Note: the pre-existing `tests/test_gemini_fix.py` fails to import on `master` (`_ensure_empty_tool_schema_for_claude` no longer exists in `src/converter/gemini_fix.py`). Untouched here, but it means `pytest tests/` currently errors at collection.