### PR TITLE
fix(converter): 流式并行工具调用 index 恒为 0，调用被归并成一个并进而触发空回

### DIFF
--- a/src/converter/openai2gemini.py
+++ b/src/converter/openai2gemini.py
@@ -6,6 +6,7 @@ OpenAI Transfer Module - Handles conversion between OpenAI and Gemini API format
 import json
 import time
 import uuid
+from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from pypinyin import Style, lazy_pinyin
@@ -19,6 +20,27 @@ from src.converter.thoughtSignature_fix import (
 from src.converter.utils import merge_system_messages
 
 from log import log
+
+#: 流式响应里每个 response_id 已分配到的工具调用序号。
+#: Gemini 的并行 functionCall 是「一个 chunk 一个 part」，若用 chunk 内 parts
+#: 下标当 OpenAI 的 tool_calls[].index，每个调用都会拿到 0；而按 OpenAI 流式规范
+#: 归并分片的客户端会把它们并进同一个 slot，arguments 拼成 `{"a":1}{"b":2}` 这种
+#: 非法 JSON。这里改按流内递增序号分配。
+_STREAM_TOOL_INDEX: "OrderedDict[str, int]" = OrderedDict()
+
+#: 上限：流被中途放弃（客户端断开、没有带 finishReason 的收尾块）时不会回收，
+#: 用 LRU 淘汰兜底，避免长期运行的实例无界增长。
+_STREAM_TOOL_INDEX_MAX_ENTRIES = 512
+
+
+def _next_stream_tool_call_indices(response_id: str, count: int) -> List[int]:
+    """为本 chunk 内的 count 个工具调用分配连续的流内序号。"""
+    base = _STREAM_TOOL_INDEX.get(response_id, 0)
+    _STREAM_TOOL_INDEX[response_id] = base + count
+    _STREAM_TOOL_INDEX.move_to_end(response_id)
+    while len(_STREAM_TOOL_INDEX) > _STREAM_TOOL_INDEX_MAX_ENTRIES:
+        _STREAM_TOOL_INDEX.popitem(last=False)
+    return list(range(base, base + count))
 
 def _convert_usage_metadata(usage_metadata: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """
@@ -1716,6 +1738,14 @@ def convert_gemini_to_openai_stream(
         # 提取工具调用和文本内容 (流式需要 index)
         tool_calls, text_content = extract_tool_calls_from_parts(parts, is_streaming=True)
 
+        # extract_tool_calls_from_parts 给出的 index 是 chunk 内 parts 下标，
+        # 对并行调用恒为 0。改用流内递增序号，客户端才能把它们归并成独立调用。
+        if tool_calls:
+            for tool_call, stream_index in zip(
+                tool_calls, _next_stream_tool_call_indices(response_id, len(tool_calls))
+            ):
+                tool_call["index"] = stream_index
+
         # 提取多种类型的内容
         content_parts = []
         reasoning_parts = []
@@ -1803,6 +1833,10 @@ def convert_gemini_to_openai_stream(
             "delta": delta,
             "finish_reason": finish_reason,
         })
+
+    # 流已收尾，回收该 response_id 占用的工具调用序号
+    if any(choice.get("finish_reason") for choice in choices):
+        _STREAM_TOOL_INDEX.pop(response_id, None)
 
     # 转换 usageMetadata (只在流结束时存在)
     usage = _convert_usage_metadata(gemini_response.get("usageMetadata"))

--- a/src/converter/openai2gemini.py
+++ b/src/converter/openai2gemini.py
@@ -1377,8 +1377,52 @@ async def convert_openai_to_gemini_request(openai_request: Dict[str, Any]) -> Di
 
                     parts.append(function_call_part)
                 except (json.JSONDecodeError, KeyError) as e:
-                    log.error(f"Failed to parse tool call: {e}")
-                    continue
+                    # 不能直接丢掉这个 functionCall：历史里它后面必然跟着一条
+                    # functionResponse，父调用一消失它就成了孤儿，Gemini 会返回
+                    # 空 candidate（0 completion token、finishReason=STOP）。
+                    # 降级保留：能救出第一个 JSON 对象就用它，否则用空参数。
+                    degraded_name = ""
+                    try:
+                        degraded_name = tool_call["function"]["name"]
+                    except (KeyError, TypeError):
+                        degraded_name = ""
+                    if not degraded_name:
+                        log.error(f"Failed to parse tool call (dropped, no name): {e}")
+                        continue
+
+                    try:
+                        raw_args = tool_call["function"]["arguments"]
+                    except (KeyError, TypeError):
+                        raw_args = ""
+                    degraded_args = {}
+                    if isinstance(raw_args, str) and raw_args:
+                        try:
+                            recovered, _ = json.JSONDecoder().raw_decode(raw_args.lstrip())
+                        except ValueError:
+                            recovered = None
+                        if isinstance(recovered, dict):
+                            degraded_args = recovered
+                    if degraded_args and degraded_name in tool_schemas:
+                        degraded_args = fix_tool_call_args_types(
+                            degraded_args, tool_schemas[degraded_name]
+                        )
+
+                    original_id, _signature = decode_tool_id_and_signature(
+                        tool_call.get("id", "")
+                    )
+                    log.warning(
+                        f"Failed to parse tool call: {e} - keeping degraded functionCall "
+                        f"name={degraded_name} "
+                        f"args={'partial' if degraded_args else 'empty'}"
+                    )
+                    parts.append({
+                        "functionCall": {
+                            "id": original_id,
+                            "name": degraded_name,
+                            "args": degraded_args,
+                        },
+                        "thoughtSignature": SKIP_THOUGHT_SIGNATURE_VALIDATOR,
+                    })
 
             if parts:
                 contents.append({"role": role, "parts": parts})

--- a/tests/test_openai2gemini_tool_calls.py
+++ b/tests/test_openai2gemini_tool_calls.py
@@ -1,0 +1,112 @@
+import asyncio
+import json
+
+from src.converter.openai2gemini import (
+    _STREAM_TOOL_INDEX,
+    convert_gemini_to_openai_stream,
+    convert_openai_to_gemini_request,
+)
+
+
+def _chunk(function_name, args, finish_reason=None):
+    """构造一个只带单个 functionCall part 的 Gemini 流式块。"""
+    candidate = {"content": {"role": "model", "parts": [{"functionCall": {"name": function_name, "args": args}}]}}
+    if finish_reason:
+        candidate["finishReason"] = finish_reason
+    return "data: " + json.dumps({"candidates": [candidate]})
+
+
+def _tool_calls_of(sse):
+    payload = json.loads(sse[len("data: "):])
+    return payload["choices"][0]["delta"].get("tool_calls", [])
+
+
+def test_parallel_tool_calls_get_distinct_stream_indices():
+    """并行 functionCall 分散在多个 chunk 里，index 必须递增而不是全为 0。"""
+    response_id = "resp-parallel"
+    _STREAM_TOOL_INDEX.pop(response_id, None)
+
+    indices = []
+    for city in ("北京", "上海", "广州"):
+        sse = convert_gemini_to_openai_stream(_chunk("get_weather", {"city": city}), "gemini-3.5-flash", response_id)
+        indices.append(_tool_calls_of(sse)[0]["index"])
+
+    assert indices == [0, 1, 2]
+
+
+def test_tool_calls_in_one_chunk_are_numbered_consecutively():
+    response_id = "resp-single-chunk"
+    _STREAM_TOOL_INDEX.pop(response_id, None)
+
+    chunk = "data: " + json.dumps({
+        "candidates": [{"content": {"role": "model", "parts": [
+            {"text": "先查两个城市"},
+            {"functionCall": {"name": "get_weather", "args": {"city": "北京"}}},
+            {"functionCall": {"name": "get_weather", "args": {"city": "上海"}}},
+        ]}}]
+    })
+    sse = convert_gemini_to_openai_stream(chunk, "gemini-3.5-flash", response_id)
+
+    assert [tc["index"] for tc in _tool_calls_of(sse)] == [0, 1]
+
+
+def test_stream_index_is_isolated_per_response_id():
+    _STREAM_TOOL_INDEX.pop("resp-a", None)
+    _STREAM_TOOL_INDEX.pop("resp-b", None)
+
+    convert_gemini_to_openai_stream(_chunk("f", {"x": 1}), "gemini-3.5-flash", "resp-a")
+    sse_b = convert_gemini_to_openai_stream(_chunk("f", {"x": 1}), "gemini-3.5-flash", "resp-b")
+    sse_a = convert_gemini_to_openai_stream(_chunk("f", {"x": 2}), "gemini-3.5-flash", "resp-a")
+
+    assert _tool_calls_of(sse_b)[0]["index"] == 0
+    assert _tool_calls_of(sse_a)[0]["index"] == 1
+
+
+def test_stream_index_released_after_finish_reason():
+    response_id = "resp-finish"
+    _STREAM_TOOL_INDEX.pop(response_id, None)
+
+    convert_gemini_to_openai_stream(_chunk("f", {"x": 1}), "gemini-3.5-flash", response_id)
+    convert_gemini_to_openai_stream(_chunk("f", {"x": 2}, finish_reason="STOP"), "gemini-3.5-flash", response_id)
+
+    assert response_id not in _STREAM_TOOL_INDEX
+
+
+def test_unparsable_tool_call_arguments_keep_function_call():
+    """arguments 非法时仍要保留 functionCall，否则后面的 functionResponse 变孤儿。"""
+    # 拼接串：正是 index 恒为 0 时客户端归并出来的产物
+    broken_args = '{"city": "北京"}{"city": "上海"}'
+    request = {
+        "model": "gemini-3.5-flash",
+        "messages": [
+            {"role": "user", "content": "查天气"},
+            {"role": "assistant", "content": None, "tool_calls": [
+                {"id": "call_abc", "type": "function",
+                 "function": {"name": "get_weather", "arguments": broken_args}}
+            ]},
+            {"role": "tool", "tool_call_id": "call_abc", "name": "get_weather", "content": "参数解析失败"},
+        ],
+        "tools": [{"type": "function", "function": {
+            "name": "get_weather",
+            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}}}],
+    }
+
+    gemini_request = asyncio.run(convert_openai_to_gemini_request(request))
+    contents = gemini_request["contents"]
+
+    function_calls = [
+        part["functionCall"]
+        for content in contents for part in content.get("parts", [])
+        if "functionCall" in part
+    ]
+    function_responses = [
+        part for content in contents for part in content.get("parts", [])
+        if "functionResponse" in part
+    ]
+
+    # functionResponse 不能没有对应的 functionCall
+    assert len(function_calls) == 1
+    assert len(function_responses) == 1
+    assert function_calls[0]["name"] == "get_weather"
+    # 救出拼接串里的第一个 JSON 对象
+    assert function_calls[0]["args"] == {"city": "北京"}


### PR DESCRIPTION
## 问题

OpenAI 兼容的**流式**响应里，Gemini 的并行 `functionCall` 全部拿到 `tool_calls[].index = 0`，导致按 OpenAI 流式规范归并分片的客户端把 N 个并行调用合成一个。

`extract_tool_calls_from_parts()` 用的是 **chunk 内 parts 数组的下标**当 index；而 Gemini 的并行调用是「一个 chunk 一个 part」，所以每个都是 0。

复现（`master`，任意有效凭证）：

```bash
curl -N http://127.0.0.1:7861/v1/chat/completions \
  -H 'Authorization: Bearer <API_PASSWORD>' -H 'Content-Type: application/json' -d '{
    "model":"gemini-3.5-flash","stream":true,
    "messages":[{"role":"user","content":"同时查北京、上海、广州的天气，在同一轮里并行调用三次"}],
    "tools":[{"type":"function","function":{"name":"get_weather",
      "parameters":{"type":"object","properties":{"city":{"type":"string"}}}}}]}'
```

```
补丁前： index=0 {"city":"北京"} / index=0 {"city":"上海"} / index=0 {"city":"广州"}
补丁后： index=0 {"city":"北京"} / index=1 {"city":"上海"} / index=2 {"city":"广州"}
```

客户端归并后得到的是一个 `arguments = '{"city":"北京"}{"city":"上海"}{"city":"广州"}'` 的调用 —— 非法 JSON，且 `id`/`name` 只剩最后一个（多工具场景下调用会顶着别的工具的名字回来）。

## 连锁反应：对话静默中断

坏掉的 `arguments` 会被客户端原样写进对话历史回传。下一轮 `convert_openai_to_gemini_request()` 解析失败后 `continue` 掉整个 `functionCall` part —— 但它后面必然跟着一条对应的 `functionResponse`，父调用一消失它就成了孤儿；若该轮 parts 全被丢空，`if parts:` 不成立，整个 assistant 轮次都不进 `contents`。

这种自相矛盾的上下文下 Gemini 返回**空 candidate**：0 completion token、`finishReason=STOP`。OpenAI 侧看到「正常停止 + 无 tool_calls + content 为空」，不少 agent 框架会判定任务正常结束 —— 用户侧表现为对话毫无征兆地静默中断，日志里只留一行「运行完成」。

实测某 agent 应用换到本项目当天，369 次调用里出现 8 次 0-token 空回（换之前两天 262 次调用、0 次），三个会话就这样断在半路。

```
master:  并行调用 index = [0, 0, 0]
         历史转换后 functionCall=0 functionResponse=1 → 孤儿 functionResponse!
本 PR:   并行调用 index = [0, 1, 2]
         历史转换后 functionCall=1 functionResponse=1 → 配对正常
```

## 改动

**1. 流式 `index` 按流内序号递增** — 按 `response_id` 维护跨 chunk 的递增计数器；流带 `finishReason` 收尾时回收，另有 LRU 上限（512）兜底客户端中途断开不回收的情况。无需改动任何调用点。

**2. `arguments` 非法时降级保留 `functionCall`** — 不再整段丢弃。用 `raw_decode` 救出第一个合法 JSON 对象（拼接串场景下正好是第一个调用的真实参数），救不出就用空参数；只有连 `name` 都拿不到才丢弃。这样模型看到的是「这次调用失败了，重试」，而不是一段缺了父调用的历史。日志级别相应从 `error` 降为 `warning`。

第 2 条独立于第 1 条也有价值：任何来源的畸形 `arguments`（其它中转、客户端 bug）都会触发同一条静默中断路径。两条拆成了独立 commit，需要的话可以只取其一。

## 测试

新增 `tests/test_openai2gemini_tool_calls.py`（5 个用例，跟 `test_gemini_fix.py` 一样 force-add，因为 `.gitignore` 忽略了 `tests/`）：并行调用 index 递增、同 chunk 内连续编号、不同 `response_id` 互不干扰、收尾后回收、非法 `arguments` 下 `functionCall`/`functionResponse` 保持配对。

```
tests/test_openai2gemini_tool_calls.py .....                             [100%]
5 passed
```

顺带一提：`tests/test_gemini_fix.py` 在当前 `master` 上已经收集失败（`_ensure_empty_tool_schema_for_claude` 已从 `src/converter/gemini_fix.py` 移除），与本 PR 无关，没有一并改。
