### PR TITLE
fix(converter): OpenAI 流式响应含 tool_calls 时收尾 chunk 正确返回 finish_reason …

### DIFF
--- a/src/converter/openai2gemini.py
+++ b/src/converter/openai2gemini.py
@@ -1458,6 +1458,17 @@ async def convert_openai_to_gemini_request(openai_request: Dict[str, Any]) -> Di
     flush_pending_tool_parts()
     _sanitize_openai_roundtrip_signatures(contents)
 
+    # 强化修复: 合并相邻相同 role 的 contents (Gemini 强制要求交替角色，避免多轮 tool 后紧跟 user 导致 0-token 空回)
+    merged_contents = []
+    for c in contents:
+        if not c.get("parts"):
+            continue
+        if merged_contents and merged_contents[-1]["role"] == c["role"]:
+            merged_contents[-1]["parts"].extend(c["parts"])
+        else:
+            merged_contents.append(c)
+    contents = merged_contents
+
     # 构建生成配置
     generation_config = {}
     model = openai_request.get("model", "")

--- a/src/converter/openai2gemini.py
+++ b/src/converter/openai2gemini.py
@@ -1869,7 +1869,10 @@ def convert_gemini_to_openai_stream(
         
         # 只有在正常停止（STOP）且有工具调用时才设为 tool_calls
         # 避免在 SAFETY、MAX_TOKENS 等情况下仍然返回 tool_calls 导致循环
-        if tool_calls and gemini_finish_reason == "STOP":
+        # 注意: 流式响应中 tool_calls 通常在前序 chunk，收尾 chunk 的 tool_calls 为空，
+        # 需检查当前流 (response_id) 之前是否分配过工具调用序号 (_STREAM_TOOL_INDEX > 0)。
+        had_tools = bool(tool_calls or _STREAM_TOOL_INDEX.get(response_id, 0) > 0)
+        if had_tools and gemini_finish_reason == "STOP":
             finish_reason = "tool_calls"
 
         choices.append({

--- a/tests/test_openai2gemini_tool_calls.py
+++ b/tests/test_openai2gemini_tool_calls.py
@@ -110,3 +110,33 @@ def test_unparsable_tool_call_arguments_keep_function_call():
     assert function_calls[0]["name"] == "get_weather"
     # 救出拼接串里的第一个 JSON 对象
     assert function_calls[0]["args"] == {"city": "北京"}
+
+
+def test_streaming_tool_call_finishes_with_tool_calls_reason():
+    """当前序 chunk 产生过 tool_calls，最后一个收尾 chunk (STOP) 的 finish_reason 必须是 tool_calls 而非 stop。"""
+    response_id = "resp-tool-finish"
+    _STREAM_TOOL_INDEX.pop(response_id, None)
+
+    # 第 1 个 chunk: 带 functionCall，finishReason 为 None
+    chunk1 = convert_gemini_to_openai_stream(
+        _chunk("get_weather", {"city": "北京"}),
+        "gemini-3.5-flash",
+        response_id
+    )
+    p1 = json.loads(chunk1[len("data: "):])
+    assert p1["choices"][0]["finish_reason"] is None
+    assert len(p1["choices"][0]["delta"]["tool_calls"]) == 1
+
+    # 第 2 个 chunk (收尾): 不带 parts/tool_calls，携带 finishReason="STOP"
+    stop_chunk = "data: " + json.dumps({
+        "candidates": [{"content": {"role": "model", "parts": []}, "finishReason": "STOP"}]
+    })
+    chunk2 = convert_gemini_to_openai_stream(
+        stop_chunk,
+        "gemini-3.5-flash",
+        response_id
+    )
+    p2 = json.loads(chunk2[len("data: "):])
+    assert p2["choices"][0]["finish_reason"] == "tool_calls"
+    assert response_id not in _STREAM_TOOL_INDEX
+

--- a/tests/test_openai2gemini_tool_calls.py
+++ b/tests/test_openai2gemini_tool_calls.py
@@ -140,3 +140,44 @@ def test_streaming_tool_call_finishes_with_tool_calls_reason():
     assert p2["choices"][0]["finish_reason"] == "tool_calls"
     assert response_id not in _STREAM_TOOL_INDEX
 
+
+def test_convert_openai_request_merges_adjacent_same_role_contents():
+    """测试多轮请求中 tool 响应后紧跟 user 提示时，相邻同 role 的 contents 会被正确合并，满足 Gemini 交替角色要求。"""
+    import asyncio
+    from src.converter.openai2gemini import convert_openai_to_gemini_request
+
+    openai_req = {
+        "model": "gemini-3.5-flash",
+        "messages": [
+            {"role": "user", "content": "第一步"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{\"cmd\": \"ls\"}"}
+                    }
+                ]
+            },
+            {"role": "tool", "tool_call_id": "call_1", "name": "terminal", "content": "ok"},
+            {"role": "user", "content": "第二步"}
+        ]
+    }
+
+    result = asyncio.run(convert_openai_to_gemini_request(openai_req))
+    contents = result.get("contents", [])
+
+    # 校验角色必须严格交替
+    for i in range(len(contents) - 1):
+        assert contents[i]["role"] != contents[i+1]["role"], f"检测到连续相同角色: index {i} 和 {i+1} 都是 {contents[i]['role']}"
+
+    # 末尾的 user content 应该合并了 tool 的 functionResponse 和 user 的 text
+    last_user_content = contents[-1]
+    assert last_user_content["role"] == "user"
+    part_types = [list(p.keys())[0] for p in last_user_content["parts"]]
+    assert "functionResponse" in part_types
+    assert "text" in part_types
+
+


### PR DESCRIPTION
## 问题描述
在 OpenAI 兼容的流式响应中，Gemini 上游通常在首个 chunk 返回 `functionCall`（此时 `finishReason` 为 null），并在最后一个 chunk 返回 `finishReason: "STOP"`（此时 `parts` 中不再包含 `functionCall`）。

原先的判断逻辑：
```python
if tool_calls and gemini_finish_reason == "STOP":
    finish_reason = "tool_calls"