### PR TITLE
feat: add configurable Antigravity safetySettings controls and request-body inspector

### DIFF
--- a/config.py
+++ b/config.py
@@ -40,6 +40,9 @@ ENV_MAPPINGS = {
     "RETURN_THOUGHTS_TO_FRONTEND": "return_thoughts_to_frontend",
     "ANTIGRAVITY_STREAM2NOSTREAM": "antigravity_stream2nostream",
     "ANTIGRAVITY_SWITCH_CREDENTIAL": "antigravity_switch_credential_enabled",
+    "ANTIGRAVITY_SAFETY_SETTINGS_ENABLED": "antigravity_safety_settings_enabled",
+    "ANTIGRAVITY_SAFETY_THRESHOLD": "antigravity_safety_threshold",
+    "ANTIGRAVITY_SAFETY_MODEL_RULES_ENABLED": "antigravity_safety_model_rules_enabled",
     "HOST": "host",
     "PORT": "port",
     "API_PASSWORD": "api_password",
@@ -371,6 +374,44 @@ async def get_antigravity_switch_credential_enabled() -> bool:
         return env_value.lower() in ("true", "1", "yes", "on")
 
     return bool(await get_config_value("antigravity_switch_credential_enabled", False))
+
+
+async def get_antigravity_safety_settings_enabled() -> bool:
+    """Whether outbound Antigravity inference requests include safetySettings.
+
+    Default is False to preserve the historical gcli2api wire behavior.
+    """
+    env_value = os.getenv("ANTIGRAVITY_SAFETY_SETTINGS_ENABLED")
+    if env_value:
+        return env_value.lower() in ("true", "1", "yes", "on")
+    return bool(await get_config_value("antigravity_safety_settings_enabled", False))
+
+
+async def get_antigravity_safety_threshold() -> str:
+    """Return the configured outbound threshold: OFF or BLOCK_NONE.
+
+    BLOCK_NONE is the default because it matches the threshold already present in
+    the repository's DEFAULT_SAFETY_SETTINGS/LITE_SAFETY_SETTINGS constants.
+    """
+    value = await get_config_value(
+        "antigravity_safety_threshold", "BLOCK_NONE", "ANTIGRAVITY_SAFETY_THRESHOLD"
+    )
+    normalized = str(value or "").strip().upper()
+    return normalized if normalized in {"OFF", "BLOCK_NONE"} else "BLOCK_NONE"
+
+
+async def get_antigravity_safety_model_rules_enabled() -> bool:
+    """Whether per-model safety compatibility overrides are active."""
+    env_value = os.getenv("ANTIGRAVITY_SAFETY_MODEL_RULES_ENABLED")
+    if env_value:
+        return env_value.lower() in ("true", "1", "yes", "on")
+    return bool(await get_config_value("antigravity_safety_model_rules_enabled", True))
+
+
+async def get_antigravity_safety_model_rules() -> list:
+    """Return the persisted model-rule array without maintaining a second cache."""
+    rules = await get_config_value("antigravity_safety_model_rules", [])
+    return rules if isinstance(rules, list) else []
 
 
 async def get_oauth_proxy_url() -> str:

--- a/front/antigravity_safety.js
+++ b/front/antigravity_safety.js
@@ -1,0 +1,385 @@
+// Antigravity safetySettings 控制面板扩展。
+// 在 common.js 之后加载，只维护自身状态，并在桌面端/移动端的 Antigravity 兼容设置旁插入 UI。
+(function () {
+    'use strict';
+
+    const state = {
+        models: [],
+        categoriesByModel: {},
+        modelLabels: {},
+        defaultCategories: [],
+        rules: []
+    };
+
+    function esc(value) {
+        return String(value ?? '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    }
+
+    function injectStyles() {
+        if (document.getElementById('antigravitySafetyStyles')) return;
+        const style = document.createElement('style');
+        style.id = 'antigravitySafetyStyles';
+        style.textContent = `
+            .ag-safety-box { margin-top: 14px; padding: 14px; border: 1px solid #90caf9; border-radius: 8px; background: #f7fbff; }
+            .ag-safety-title { font-weight: 700; color: #0d47a1; margin-bottom: 10px; }
+            .ag-safety-grid { display: grid; grid-template-columns: minmax(180px, 1.1fr) minmax(180px, .9fr) minmax(280px, 2fr) auto; gap: 10px; align-items: start; }
+            .ag-safety-head { font-size: 12px; font-weight: 700; color: #455a64; padding: 0 4px; }
+            .ag-safety-row { display: contents; }
+            .ag-safety-row select { width: 100%; min-height: 36px; }
+            .ag-safety-categories { display: flex; flex-wrap: wrap; gap: 6px; min-height: 36px; align-items: center; }
+            .ag-safety-chip { border: 1px solid #9e9e9e; border-radius: 999px; padding: 5px 8px; background: #fff; color: #37474f; cursor: pointer; font-size: 11px; line-height: 1.2; }
+            .ag-safety-chip.excluded { border-color: #c62828; background: #ffebee; color: #b71c1c; text-decoration: line-through; font-weight: 700; }
+            .ag-safety-chip.unsupported { cursor: not-allowed; opacity: .78; }
+            .ag-safety-delete { border: 1px solid #ef9a9a; background: #fff; color: #c62828; border-radius: 5px; padding: 7px 10px; cursor: pointer; }
+            .ag-safety-unavailable { color: #ef6c00; font-size: 11px; margin-top: 4px; }
+            .ag-safety-empty { grid-column: 1 / -1; color: #78909c; padding: 10px 4px; font-size: 13px; }
+            .ag-safety-disabled { opacity: .55; }
+            .ag-safety-toolbar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-top: 10px; }
+            .ag-safety-toolbar button { padding: 7px 11px; cursor: pointer; }
+            .ag-safety-help { margin-top: 8px; color: #546e7a; font-size: 12px; line-height: 1.5; }
+            @media (max-width: 780px) {
+                .ag-safety-grid { display: block; }
+                .ag-safety-head { display: none; }
+                .ag-safety-row { display: block; padding: 10px 0; border-top: 1px solid #dbe9f3; }
+                .ag-safety-row > * { margin-bottom: 8px; }
+                .ag-safety-row select { width: 100%; }
+                .ag-safety-categories { margin-top: 4px; }
+            }
+        `;
+        document.head.appendChild(style);
+    }
+
+    function injectUI() {
+        if (document.getElementById('antigravitySafetySettingsEnabled')) return;
+        const anchor = document.getElementById('antigravitySwitchCredentialEnabled');
+        if (!anchor) return;
+        const anchorGroup = anchor.closest('.form-group');
+        if (!anchorGroup) return;
+
+        injectStyles();
+        const box = document.createElement('div');
+        box.className = 'ag-safety-box';
+        box.id = 'antigravitySafetyBox';
+        box.innerHTML = `
+            <div class="ag-safety-title">🛡️ Antigravity safetySettings 兼容性控制</div>
+            <div class="form-group">
+                <label>
+                    <input type="checkbox" id="antigravitySafetySettingsEnabled" class="config-checkbox" />
+                    向 Antigravity 发送 safetySettings
+                </label>
+                <small class="config-note">关闭时保持原有行为：从最终请求中移除 safetySettings。开启时保留 gcli2api 当前按模型生成的完整 category 列表，并使用下方 threshold。支持热更新。</small>
+            </div>
+            <div class="form-group">
+                <label for="antigravitySafetyThreshold">Safety threshold:</label>
+                <select id="antigravitySafetyThreshold" class="config-input">
+                    <option value="BLOCK_NONE">BLOCK_NONE</option>
+                    <option value="OFF">OFF</option>
+                </select>
+                <small class="config-note">仅控制请求中发送的可配置 threshold；不代表关闭模型或产品层的其他安全机制。</small>
+            </div>
+            <div class="form-group">
+                <label>
+                    <input type="checkbox" id="antigravitySafetyModelRulesEnabled" class="config-checkbox" />
+                    启用 Model Safety Overrides
+                </label>
+                <small class="config-note">规则按最终发送给 Antigravity 的 canonical model ID 精确匹配。因此抗截断/假流式等本地变体会自动继承同一后端模型的规则。</small>
+            </div>
+            <div id="antigravitySafetyRulesArea">
+                <div class="ag-safety-grid" id="antigravitySafetyRulesGrid"></div>
+                <div class="ag-safety-toolbar">
+                    <button type="button" id="addAntigravitySafetyRuleBtn">＋ 添加模型规则</button>
+                    <span style="font-size:12px;color:#607d8b;">红色 category = 不发送；模型本身不支持的 category 会默认标红并锁定，手动排除的 category 可再次点击恢复。</span>
+                </div>
+            </div>
+            <div class="ag-safety-help">模型列表从 Antigravity <code>fetchAvailableModels</code> 获取。界面可使用更易懂的显示名，但规则内部仍绑定 Google 返回的 canonical model ID。若已保存的模型暂时不在当前列表中，该规则仍保留并可删除。</div>
+        `;
+        anchorGroup.insertAdjacentElement('afterend', box);
+
+        document.getElementById('antigravitySafetySettingsEnabled').addEventListener('change', refreshEnabledState);
+        document.getElementById('antigravitySafetyModelRulesEnabled').addEventListener('change', refreshEnabledState);
+        document.getElementById('addAntigravitySafetyRuleBtn').addEventListener('click', addRule);
+    }
+
+    function isEnvLocked(key) {
+        return !!(typeof AppState !== 'undefined' && AppState.envLockedFields && AppState.envLockedFields.has(key));
+    }
+
+    function getCategories(model) {
+        const key = String(model || '').toLowerCase();
+        const categories = state.categoriesByModel[key];
+        return Array.isArray(categories) && categories.length
+            ? [...categories]
+            : [...state.defaultCategories];
+    }
+
+    function selectedModelsExcept(index) {
+        return new Set(
+            state.rules
+                .map((rule, i) => i === index ? '' : String(rule.model || '').toLowerCase())
+                .filter(Boolean)
+        );
+    }
+
+    function renderRules() {
+        const grid = document.getElementById('antigravitySafetyRulesGrid');
+        if (!grid) return;
+
+        if (!state.rules.length) {
+            grid.innerHTML = '<div class="ag-safety-empty">暂无模型规则。未匹配模型将使用全局 safetySettings 配置。</div>';
+            refreshEnabledState();
+            return;
+        }
+
+        let html = `
+            <div class="ag-safety-head">模型</div>
+            <div class="ag-safety-head">模式</div>
+            <div class="ag-safety-head">safetySettings categories</div>
+            <div class="ag-safety-head"></div>
+        `;
+
+        state.rules.forEach((rule, index) => {
+            const model = String(rule.model || '').toLowerCase();
+            const usedElsewhere = selectedModelsExcept(index);
+            const currentAvailable = state.models.includes(model);
+            const optionModels = currentAvailable || !model ? [...state.models] : [model, ...state.models];
+            const uniqueModels = [...new Set(optionModels)];
+            const modelOptions = uniqueModels.map(option => {
+                const unavailable = !state.models.includes(option);
+                const disabled = usedElsewhere.has(option);
+                const displayLabel = state.modelLabels[option] || option;
+                return `<option value="${esc(option)}" ${option === model ? 'selected' : ''} ${disabled ? 'disabled' : ''}>${esc(displayLabel)}${unavailable ? ' (当前列表不可用)' : ''}</option>`;
+            }).join('');
+
+            const mode = rule.mode === 'exclude_all' ? 'exclude_all' : 'filter_categories';
+            const excluded = new Set(Array.isArray(rule.excluded_categories) ? rule.excluded_categories : []);
+            const supportedCategories = new Set(getCategories(model));
+            const categories = state.defaultCategories.length ? [...state.defaultCategories] : [...supportedCategories];
+            const chips = mode === 'filter_categories'
+                ? categories.map(category => {
+                    const unsupported = !supportedCategories.has(category);
+                    const visuallyExcluded = unsupported || excluded.has(category);
+                    const title = unsupported
+                        ? '该模型的 safetySettings 不包含此 category，因此本来就不会发送'
+                        : (excluded.has(category) ? '已排除，不会发送' : '当前会发送');
+                    return `
+                    <button type="button" class="ag-safety-chip ${visuallyExcluded ? 'excluded' : ''} ${unsupported ? 'unsupported' : ''}"
+                        data-rule-index="${index}" data-category="${esc(category)}" data-unsupported="${unsupported ? 'true' : 'false'}"
+                        ${unsupported ? 'disabled' : ''} title="${esc(title)}">${esc(category)}</button>
+                    `;
+                }).join('')
+                : '<span style="font-size:12px;color:#b71c1c;font-weight:700;">整个 safetySettings 字段将被移除</span>';
+
+            html += `
+                <div class="ag-safety-row" data-rule-row="${index}">
+                    <div>
+                        <select class="config-input ag-safety-model" data-rule-index="${index}">${modelOptions}</select>
+                        ${!currentAvailable && model ? '<div class="ag-safety-unavailable">⚠ 当前 fetchAvailableModels 未返回该模型；规则仍会保留。</div>' : ''}
+                    </div>
+                    <div>
+                        <select class="config-input ag-safety-mode" data-rule-index="${index}">
+                            <option value="exclude_all" ${mode === 'exclude_all' ? 'selected' : ''}>排除发送 safetySettings</option>
+                            <option value="filter_categories" ${mode === 'filter_categories' ? 'selected' : ''}>过滤 category</option>
+                        </select>
+                    </div>
+                    <div class="ag-safety-categories">${chips}</div>
+                    <div><button type="button" class="ag-safety-delete" data-rule-index="${index}">删除</button></div>
+                </div>
+            `;
+        });
+
+        grid.innerHTML = html;
+
+        grid.querySelectorAll('.ag-safety-model').forEach(select => {
+            select.addEventListener('change', event => changeRuleModel(Number(event.target.dataset.ruleIndex), event.target.value));
+        });
+        grid.querySelectorAll('.ag-safety-mode').forEach(select => {
+            select.addEventListener('change', event => changeRuleMode(Number(event.target.dataset.ruleIndex), event.target.value));
+        });
+        grid.querySelectorAll('.ag-safety-chip').forEach(chip => {
+            chip.addEventListener('click', event => toggleCategory(Number(event.currentTarget.dataset.ruleIndex), event.currentTarget.dataset.category));
+        });
+        grid.querySelectorAll('.ag-safety-delete').forEach(button => {
+            button.addEventListener('click', event => deleteRule(Number(event.currentTarget.dataset.ruleIndex)));
+        });
+
+        refreshEnabledState();
+    }
+
+    function refreshEnabledState() {
+        const enabled = !!document.getElementById('antigravitySafetySettingsEnabled')?.checked;
+        const rulesEnabled = !!document.getElementById('antigravitySafetyModelRulesEnabled')?.checked;
+        const threshold = document.getElementById('antigravitySafetyThreshold');
+        const rulesToggle = document.getElementById('antigravitySafetyModelRulesEnabled');
+        const rulesArea = document.getElementById('antigravitySafetyRulesArea');
+        const addButton = document.getElementById('addAntigravitySafetyRuleBtn');
+
+        if (threshold) threshold.disabled = !enabled || isEnvLocked('antigravity_safety_threshold');
+        if (rulesToggle) rulesToggle.disabled = !enabled || isEnvLocked('antigravity_safety_model_rules_enabled');
+        if (rulesArea) rulesArea.classList.toggle('ag-safety-disabled', !enabled || !rulesEnabled);
+        if (addButton) addButton.disabled = !enabled || !rulesEnabled;
+
+        document.querySelectorAll('#antigravitySafetyRulesGrid select, #antigravitySafetyRulesGrid button').forEach(el => {
+            const modelUnsupported = el.dataset?.unsupported === 'true';
+            el.disabled = !enabled || !rulesEnabled || modelUnsupported;
+        });
+
+        const globalToggle = document.getElementById('antigravitySafetySettingsEnabled');
+        if (globalToggle && isEnvLocked('antigravity_safety_settings_enabled')) globalToggle.disabled = true;
+    }
+
+    function addRule() {
+        const used = new Set(state.rules.map(rule => String(rule.model || '').toLowerCase()).filter(Boolean));
+        const model = state.models.find(candidate => !used.has(candidate));
+        if (!model) {
+            if (typeof showStatus === 'function') {
+                showStatus(state.models.length ? '所有当前可用模型都已有规则' : '当前没有可用的Antigravity模型，请先确认凭证可用', 'error');
+            }
+            return;
+        }
+        state.rules.push({ model, mode: 'filter_categories', excluded_categories: [] });
+        renderRules();
+    }
+
+    function deleteRule(index) {
+        if (!Number.isInteger(index) || index < 0 || index >= state.rules.length) return;
+        state.rules.splice(index, 1);
+        renderRules();
+    }
+
+    function changeRuleModel(index, model) {
+        const rule = state.rules[index];
+        if (!rule) return;
+        rule.model = String(model || '').toLowerCase();
+        const allowed = new Set(getCategories(rule.model));
+        rule.excluded_categories = (rule.excluded_categories || []).filter(category => allowed.has(category));
+        renderRules();
+    }
+
+    function changeRuleMode(index, mode) {
+        const rule = state.rules[index];
+        if (!rule) return;
+        rule.mode = mode === 'exclude_all' ? 'exclude_all' : 'filter_categories';
+        if (rule.mode === 'exclude_all') rule.excluded_categories = [];
+        renderRules();
+    }
+
+    function toggleCategory(index, category) {
+        const rule = state.rules[index];
+        if (!rule || rule.mode !== 'filter_categories') return;
+        if (!getCategories(rule.model).includes(category)) return;
+        const excluded = new Set(rule.excluded_categories || []);
+        if (excluded.has(category)) excluded.delete(category);
+        else excluded.add(category);
+        rule.excluded_categories = getCategories(rule.model).filter(item => excluded.has(item));
+        renderRules();
+    }
+
+    function collectConfig() {
+        return {
+            antigravity_safety_settings_enabled: !!document.getElementById('antigravitySafetySettingsEnabled')?.checked,
+            antigravity_safety_threshold: document.getElementById('antigravitySafetyThreshold')?.value || 'BLOCK_NONE',
+            antigravity_safety_model_rules_enabled: !!document.getElementById('antigravitySafetyModelRulesEnabled')?.checked,
+            // 规则数组按整体替换保存；删除一行后，该模型对象不会再发送给后端。
+            antigravity_safety_model_rules: state.rules.map(rule => ({
+                model: String(rule.model || '').toLowerCase(),
+                mode: rule.mode === 'exclude_all' ? 'exclude_all' : 'filter_categories',
+                excluded_categories: Array.isArray(rule.excluded_categories) ? [...rule.excluded_categories] : []
+            }))
+        };
+    }
+
+    async function loadOptionsAndPopulate() {
+        injectUI();
+        const c = (typeof AppState !== 'undefined' && AppState.currentConfig) || {};
+        state.rules = Array.isArray(c.antigravity_safety_model_rules)
+            ? c.antigravity_safety_model_rules.map(rule => ({
+                model: String(rule?.model || '').toLowerCase(),
+                mode: rule?.mode === 'exclude_all' ? 'exclude_all' : 'filter_categories',
+                excluded_categories: Array.isArray(rule?.excluded_categories) ? [...rule.excluded_categories] : []
+            })).filter(rule => rule.model)
+            : [];
+
+        const enabled = document.getElementById('antigravitySafetySettingsEnabled');
+        const threshold = document.getElementById('antigravitySafetyThreshold');
+        const rulesEnabled = document.getElementById('antigravitySafetyModelRulesEnabled');
+        if (enabled) enabled.checked = Boolean(c.antigravity_safety_settings_enabled);
+        if (threshold) threshold.value = c.antigravity_safety_threshold === 'OFF' ? 'OFF' : 'BLOCK_NONE';
+        if (rulesEnabled) rulesEnabled.checked = c.antigravity_safety_model_rules_enabled !== false;
+
+        try {
+            const response = await fetch('./config/antigravity-safety-options', { headers: getAuthHeaders() });
+            const data = await response.json();
+            if (!response.ok) throw new Error(data.detail || data.error || '加载模型选项失败');
+            state.models = Array.isArray(data.models) ? data.models.map(model => String(model).toLowerCase()) : [];
+            state.categoriesByModel = data.categories_by_model && typeof data.categories_by_model === 'object'
+                ? Object.fromEntries(Object.entries(data.categories_by_model).map(([model, categories]) => [String(model).toLowerCase(), Array.isArray(categories) ? categories : []]))
+                : {};
+            state.modelLabels = data.model_labels && typeof data.model_labels === 'object'
+                ? Object.fromEntries(Object.entries(data.model_labels).map(([model, label]) => [String(model).toLowerCase(), String(label || model)]))
+                : {};
+            state.defaultCategories = Array.isArray(data.default_categories) ? data.default_categories : [];
+        } catch (error) {
+            state.models = [];
+            state.categoriesByModel = {};
+            state.modelLabels = {};
+            state.defaultCategories = [];
+            console.warn('Antigravity safety options load failed:', error);
+            if (typeof showStatus === 'function') showStatus(`Safety模型选项加载失败: ${error.message}`, 'error');
+        }
+
+        renderRules();
+        refreshEnabledState();
+    }
+
+    function wrapConfigFunctions() {
+        if (typeof window.loadConfig === 'function' && !window.loadConfig.__agSafetyWrapped) {
+            const originalLoadConfig = window.loadConfig;
+            const wrappedLoadConfig = async function (...args) {
+                const result = await originalLoadConfig.apply(this, args);
+                await loadOptionsAndPopulate();
+                return result;
+            };
+            wrappedLoadConfig.__agSafetyWrapped = true;
+            window.loadConfig = wrappedLoadConfig;
+        }
+
+        if (typeof window.saveConfig === 'function' && !window.saveConfig.__agSafetyWrapped) {
+            const originalSaveConfig = window.saveConfig;
+            const wrappedSaveConfig = async function (...args) {
+                const previousFetch = window.fetch;
+                window.fetch = function (input, init) {
+                    try {
+                        const url = typeof input === 'string' ? input : input?.url;
+                        if (url === './config/save' && init && typeof init.body === 'string') {
+                            const parsed = JSON.parse(init.body);
+                            if (parsed && parsed.config && typeof parsed.config === 'object') {
+                                Object.assign(parsed.config, collectConfig());
+                                init = { ...init, body: JSON.stringify(parsed) };
+                            }
+                        }
+                    } catch (error) {
+                        console.error('Failed to attach Antigravity safety config:', error);
+                    }
+                    return previousFetch.call(window, input, init);
+                };
+
+                try {
+                    return await originalSaveConfig.apply(this, args);
+                } finally {
+                    window.fetch = previousFetch;
+                }
+            };
+            wrappedSaveConfig.__agSafetyWrapped = true;
+            window.saveConfig = wrappedSaveConfig;
+        }
+    }
+
+    injectUI();
+    wrapConfigFunctions();
+    window.AntigravitySafetyUI = { state, collectConfig, loadOptionsAndPopulate, renderRules };
+})();

--- a/front/antigravity_safety.js
+++ b/front/antigravity_safety.js
@@ -41,8 +41,17 @@
             .ag-safety-disabled { opacity: .55; }
             .ag-safety-toolbar { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-top: 10px; }
             .ag-safety-toolbar button { padding: 7px 11px; cursor: pointer; }
+            .ag-safety-search { display: none; gap: 10px; align-items: center; margin: 8px 0 10px; }
+            .ag-safety-search.visible { display: flex; }
+            .ag-safety-search input { flex: 1; min-width: 180px; padding: 7px 9px; border: 1px solid #b0bec5; border-radius: 5px; background: #fff; }
+            .ag-safety-search-count { flex: 0 0 auto; color: #607d8b; font-size: 12px; white-space: nowrap; }
+            .ag-safety-scroll.scrollable { max-height: 420px; overflow-y: auto; overscroll-behavior: contain; padding-right: 6px; }
+            .ag-safety-scroll.scrollable .ag-safety-head { position: sticky; top: 0; z-index: 2; background: #f7fbff; padding-top: 5px; padding-bottom: 5px; }
+            .ag-safety-search-empty { display: none; color: #78909c; font-size: 12px; padding: 8px 4px; }
             .ag-safety-help { margin-top: 8px; color: #546e7a; font-size: 12px; line-height: 1.5; }
             @media (max-width: 780px) {
+                .ag-safety-scroll.scrollable { max-height: 55vh; }
+                .ag-safety-search.visible { align-items: stretch; }
                 .ag-safety-grid { display: block; }
                 .ag-safety-head { display: none; }
                 .ag-safety-row { display: block; padding: 10px 0; border-top: 1px solid #dbe9f3; }
@@ -90,7 +99,14 @@
                 <small class="config-note">规则按最终发送给 Antigravity 的 canonical model ID 精确匹配。因此抗截断/假流式等本地变体会自动继承同一后端模型的规则。</small>
             </div>
             <div id="antigravitySafetyRulesArea">
-                <div class="ag-safety-grid" id="antigravitySafetyRulesGrid"></div>
+                <div class="ag-safety-search" id="antigravitySafetyRuleSearchBar">
+                    <input type="search" id="antigravitySafetyRuleSearch" placeholder="搜索已添加模型…" autocomplete="off" />
+                    <span class="ag-safety-search-count" id="antigravitySafetyRuleCount"></span>
+                </div>
+                <div class="ag-safety-scroll" id="antigravitySafetyRulesScroll">
+                    <div class="ag-safety-grid" id="antigravitySafetyRulesGrid"></div>
+                </div>
+                <div class="ag-safety-search-empty" id="antigravitySafetySearchEmpty">没有匹配的已添加模型</div>
                 <div class="ag-safety-toolbar">
                     <button type="button" id="addAntigravitySafetyRuleBtn">＋ 添加模型规则</button>
                     <span style="font-size:12px;color:#607d8b;">红色 category = 不发送；模型本身不支持的 category 会默认标红并锁定，手动排除的 category 可再次点击恢复。</span>
@@ -103,6 +119,7 @@
         document.getElementById('antigravitySafetySettingsEnabled').addEventListener('change', refreshEnabledState);
         document.getElementById('antigravitySafetyModelRulesEnabled').addEventListener('change', refreshEnabledState);
         document.getElementById('addAntigravitySafetyRuleBtn').addEventListener('click', addRule);
+        document.getElementById('antigravitySafetyRuleSearch').addEventListener('input', applyRuleSearch);
     }
 
     function isEnvLocked(key) {
@@ -125,12 +142,46 @@
         );
     }
 
+    function applyRuleSearch() {
+        const input = document.getElementById('antigravitySafetyRuleSearch');
+        const count = document.getElementById('antigravitySafetyRuleCount');
+        const empty = document.getElementById('antigravitySafetySearchEmpty');
+        const query = String(input?.value || '').trim().toLowerCase();
+        const rows = Array.from(document.querySelectorAll('#antigravitySafetyRulesGrid [data-rule-row]'));
+        let matched = 0;
+
+        rows.forEach(row => {
+            const searchable = String(row.dataset.search || '').toLowerCase();
+            const visible = !query || searchable.includes(query);
+            if (visible) {
+                row.style.removeProperty('display');
+                matched += 1;
+            } else {
+                row.style.display = 'none';
+            }
+        });
+
+        if (count) count.textContent = query ? `匹配: ${matched} / ${state.rules.length}` : `当前规则: ${state.rules.length}`;
+        if (empty) empty.style.display = state.rules.length && query && matched === 0 ? 'block' : 'none';
+    }
+
     function renderRules() {
         const grid = document.getElementById('antigravitySafetyRulesGrid');
+        const searchBar = document.getElementById('antigravitySafetyRuleSearchBar');
+        const searchInput = document.getElementById('antigravitySafetyRuleSearch');
+        const scroll = document.getElementById('antigravitySafetyRulesScroll');
+        const searchEmpty = document.getElementById('antigravitySafetySearchEmpty');
         if (!grid) return;
+
+        const useCompactList = state.rules.length >= 2;
+        if (searchBar) searchBar.classList.toggle('visible', useCompactList);
+        if (scroll) scroll.classList.toggle('scrollable', useCompactList);
+        if (!useCompactList && searchInput) searchInput.value = '';
+        if (searchEmpty) searchEmpty.style.display = 'none';
 
         if (!state.rules.length) {
             grid.innerHTML = '<div class="ag-safety-empty">暂无模型规则。未匹配模型将使用全局 safetySettings 配置。</div>';
+            applyRuleSearch();
             refreshEnabledState();
             return;
         }
@@ -144,6 +195,8 @@
 
         state.rules.forEach((rule, index) => {
             const model = String(rule.model || '').toLowerCase();
+            const displayLabel = state.modelLabels[model] || model;
+            const searchable = `${model} ${displayLabel}`.toLowerCase();
             const usedElsewhere = selectedModelsExcept(index);
             const currentAvailable = state.models.includes(model);
             const optionModels = currentAvailable || !model ? [...state.models] : [model, ...state.models];
@@ -151,8 +204,8 @@
             const modelOptions = uniqueModels.map(option => {
                 const unavailable = !state.models.includes(option);
                 const disabled = usedElsewhere.has(option);
-                const displayLabel = state.modelLabels[option] || option;
-                return `<option value="${esc(option)}" ${option === model ? 'selected' : ''} ${disabled ? 'disabled' : ''}>${esc(displayLabel)}${unavailable ? ' (当前列表不可用)' : ''}</option>`;
+                const optionLabel = state.modelLabels[option] || option;
+                return `<option value="${esc(option)}" ${option === model ? 'selected' : ''} ${disabled ? 'disabled' : ''}>${esc(optionLabel)}${unavailable ? ' (当前列表不可用)' : ''}</option>`;
             }).join('');
 
             const mode = rule.mode === 'exclude_all' ? 'exclude_all' : 'filter_categories';
@@ -175,7 +228,7 @@
                 : '<span style="font-size:12px;color:#b71c1c;font-weight:700;">整个 safetySettings 字段将被移除</span>';
 
             html += `
-                <div class="ag-safety-row" data-rule-row="${index}">
+                <div class="ag-safety-row" data-rule-row="${index}" data-search="${esc(searchable)}">
                     <div>
                         <select class="config-input ag-safety-model" data-rule-index="${index}">${modelOptions}</select>
                         ${!currentAvailable && model ? '<div class="ag-safety-unavailable">⚠ 当前 fetchAvailableModels 未返回该模型；规则仍会保留。</div>' : ''}
@@ -207,6 +260,7 @@
             button.addEventListener('click', event => deleteRule(Number(event.currentTarget.dataset.ruleIndex)));
         });
 
+        applyRuleSearch();
         refreshEnabledState();
     }
 

--- a/front/antigravity_safety.js
+++ b/front/antigravity_safety.js
@@ -336,7 +336,7 @@
         refreshEnabledState();
     }
 
-    function wrapConfigFunctions() {
+    function wrapLoadConfig() {
         if (typeof window.loadConfig === 'function' && !window.loadConfig.__agSafetyWrapped) {
             const originalLoadConfig = window.loadConfig;
             const wrappedLoadConfig = async function (...args) {
@@ -347,39 +347,9 @@
             wrappedLoadConfig.__agSafetyWrapped = true;
             window.loadConfig = wrappedLoadConfig;
         }
-
-        if (typeof window.saveConfig === 'function' && !window.saveConfig.__agSafetyWrapped) {
-            const originalSaveConfig = window.saveConfig;
-            const wrappedSaveConfig = async function (...args) {
-                const previousFetch = window.fetch;
-                window.fetch = function (input, init) {
-                    try {
-                        const url = typeof input === 'string' ? input : input?.url;
-                        if (url === './config/save' && init && typeof init.body === 'string') {
-                            const parsed = JSON.parse(init.body);
-                            if (parsed && parsed.config && typeof parsed.config === 'object') {
-                                Object.assign(parsed.config, collectConfig());
-                                init = { ...init, body: JSON.stringify(parsed) };
-                            }
-                        }
-                    } catch (error) {
-                        console.error('Failed to attach Antigravity safety config:', error);
-                    }
-                    return previousFetch.call(window, input, init);
-                };
-
-                try {
-                    return await originalSaveConfig.apply(this, args);
-                } finally {
-                    window.fetch = previousFetch;
-                }
-            };
-            wrappedSaveConfig.__agSafetyWrapped = true;
-            window.saveConfig = wrappedSaveConfig;
-        }
     }
 
     injectUI();
-    wrapConfigFunctions();
+    wrapLoadConfig();
     window.AntigravitySafetyUI = { state, collectConfig, loadOptionsAndPopulate, renderRules };
 })();

--- a/front/common.js
+++ b/front/common.js
@@ -2995,6 +2995,11 @@ async function saveConfig() {
             keepalive_interval: getInt('keepaliveInterval', 60)
         };
 
+        // Safety 配置与其他设置通过同一个公共保存请求提交。
+        if (window.AntigravitySafetyUI && typeof window.AntigravitySafetyUI.collectConfig === 'function') {
+            Object.assign(config, window.AntigravitySafetyUI.collectConfig());
+        }
+
         const response = await fetch('./config/save', {
             method: 'POST',
             headers: getAuthHeaders(),

--- a/front/common.js
+++ b/front/common.js
@@ -2579,14 +2579,176 @@ async function clearLogs() {
     }
 }
 
+const PAYLOAD_LOG_MARKER = '[PAYLOAD]';
+
+function ensurePayloadLogFilterOption() {
+    const select = document.getElementById('logLevelFilter');
+    if (!select || select.querySelector('option[value="payload"]')) return;
+
+    const option = document.createElement('option');
+    option.value = 'payload';
+    option.textContent = '请求体检查';
+    select.appendChild(option);
+}
+
+function isPayloadLog(logLine) {
+    return String(logLine || '').includes(PAYLOAD_LOG_MARKER);
+}
+
+function payloadInspectorEscapeString(value) {
+    return String(value)
+        .replace(/\\/g, '\\\\')
+        .replace(/'/g, "\\'")
+        .replace(/\r/g, '\\r')
+        .replace(/\t/g, '\\t')
+        .replace(/\u0008/g, '\\b')
+        .replace(/\f/g, '\\f');
+}
+
+function payloadInspectorQuoteString(value, level = 0) {
+    const text = String(value);
+    const wrapWidth = 96;
+    const indent = '  '.repeat(level);
+    const logicalLines = text.split('\n');
+    const fragments = [];
+
+    logicalLines.forEach((line, lineIndex) => {
+        const chars = Array.from(line);
+        if (chars.length === 0) {
+            fragments.push({
+                text: '',
+                newline: lineIndex < logicalLines.length - 1
+            });
+            return;
+        }
+
+        for (let start = 0; start < chars.length; start += wrapWidth) {
+            const isLastChunk = start + wrapWidth >= chars.length;
+            fragments.push({
+                text: chars.slice(start, start + wrapWidth).join(''),
+                newline: isLastChunk && lineIndex < logicalLines.length - 1
+            });
+        }
+    });
+
+    if (fragments.length === 0) {
+        fragments.push({ text: '', newline: false });
+    }
+
+    const quoted = fragments.map(fragment => {
+        const escaped = payloadInspectorEscapeString(fragment.text);
+        return `'${escaped}${fragment.newline ? '\\n' : ''}'`;
+    });
+
+    if (quoted.length === 1) return quoted[0];
+    return quoted.join(` +\n${indent}`);
+}
+
+function payloadInspectorKey(key) {
+    const text = String(key);
+    return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(text)
+        ? text
+        : payloadInspectorQuoteString(text, 0);
+}
+
+function payloadInspectorPrimitive(value, level = 0) {
+    if (value === null) return 'null';
+    if (value === undefined) return 'undefined';
+    if (typeof value === 'string') return payloadInspectorQuoteString(value, level);
+    if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+    return payloadInspectorQuoteString(String(value), level);
+}
+
+function payloadInspectorInline(value, depth = 0) {
+    if (value === null || typeof value !== 'object') {
+        if (typeof value === 'string') {
+            if (value.includes('\n') || Array.from(value).length > 72) return null;
+        }
+        return payloadInspectorPrimitive(value, 0);
+    }
+
+    if (depth > 3) return null;
+
+    if (Array.isArray(value)) {
+        if (value.length === 0) return '[]';
+        const children = value.map(item => payloadInspectorInline(item, depth + 1));
+        if (children.some(item => item === null)) return null;
+        const rendered = `[ ${children.join(', ')} ]`;
+        return rendered.length <= 110 ? rendered : null;
+    }
+
+    const entries = Object.entries(value);
+    if (entries.length === 0) return '{}';
+    const children = [];
+    for (const [key, item] of entries) {
+        const rendered = payloadInspectorInline(item, depth + 1);
+        if (rendered === null) return null;
+        children.push(`${payloadInspectorKey(key)}: ${rendered}`);
+    }
+    const rendered = `{ ${children.join(', ')} }`;
+    return rendered.length <= 110 ? rendered : null;
+}
+
+function formatPayloadInspectorValue(value, level = 0, forceMultiline = false) {
+    // contents 是对话主结构；即使内容较短，也保持 message/parts 层级展开，便于逐轮阅读。
+    const inline = forceMultiline && value && typeof value === 'object'
+        ? null
+        : payloadInspectorInline(value, 0);
+    if (inline !== null) return inline;
+
+    const indent = '  '.repeat(level);
+    const childIndent = '  '.repeat(level + 1);
+
+    if (Array.isArray(value)) {
+        if (value.length === 0) return '[]';
+        return '[\n' + value.map(item =>
+            `${childIndent}${formatPayloadInspectorValue(item, level + 1, forceMultiline)}`
+        ).join(',\n') + `\n${indent}]`;
+    }
+
+    if (value && typeof value === 'object') {
+        const entries = Object.entries(value);
+        if (entries.length === 0) return '{}';
+        return '{\n' + entries.map(([key, item]) => {
+            const childForceMultiline = forceMultiline || key === 'contents';
+            return `${childIndent}${payloadInspectorKey(key)}: ${formatPayloadInspectorValue(item, level + 1, childForceMultiline)}`;
+        }).join(',\n') + `\n${indent}}`;
+    }
+
+    return payloadInspectorPrimitive(value, level);
+}
+
+function formatPayloadLogEntry(logLine) {
+    const line = String(logLine || '');
+    const bodyMarker = ' body=';
+    const bodyIndex = line.indexOf(bodyMarker);
+    if (bodyIndex < 0) return line;
+
+    const rawBody = line.slice(bodyIndex + bodyMarker.length);
+    try {
+        const payload = JSON.parse(rawBody);
+        const header = line.slice(0, bodyIndex);
+        return `${header}\n${formatPayloadInspectorValue(payload, 0)}`;
+    } catch (_) {
+        // 若未来日志格式不是合法 JSON，则保留原始请求体，避免隐藏调试信息。
+        return line;
+    }
+}
+
 function filterLogs() {
+    ensurePayloadLogFilterOption();
     const filter = document.getElementById('logLevelFilter').value;
     AppState.currentLogFilter = filter;
 
-    if (filter === 'all') {
-        AppState.filteredLogs = [...AppState.allLogs];
+    if (filter === 'payload') {
+        // 请求体日志仅在“请求体检查”筛选器中显示。
+        AppState.filteredLogs = AppState.allLogs.filter(isPayloadLog);
+    } else if (filter === 'all') {
+        AppState.filteredLogs = AppState.allLogs.filter(log => !isPayloadLog(log));
     } else {
-        AppState.filteredLogs = AppState.allLogs.filter(log => log.toUpperCase().includes(filter));
+        AppState.filteredLogs = AppState.allLogs.filter(
+            log => !isPayloadLog(log) && log.toUpperCase().includes(filter.toUpperCase())
+        );
     }
 
     displayLogs();
@@ -2595,11 +2757,28 @@ function filterLogs() {
 function displayLogs() {
     const logContent = document.getElementById('logContent');
     if (AppState.filteredLogs.length === 0) {
-        logContent.textContent = AppState.currentLogFilter === 'all' ?
-            '暂无日志...' : `暂无${AppState.currentLogFilter}级别的日志...`;
+        if (AppState.currentLogFilter === 'all') {
+            logContent.textContent = '暂无日志...';
+        } else if (AppState.currentLogFilter === 'payload') {
+            logContent.textContent = '暂无请求体记录...';
+        } else {
+            logContent.textContent = `暂无${AppState.currentLogFilter}级别的日志...`;
+        }
     } else {
-        logContent.textContent = AppState.filteredLogs.join('\n');
+        if (AppState.currentLogFilter === 'payload') {
+            logContent.textContent = AppState.filteredLogs
+                .map(formatPayloadLogEntry)
+                .join('\n\n');
+        } else {
+            logContent.textContent = AppState.filteredLogs.join('\n');
+        }
     }
+}
+
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', ensurePayloadLogFilterOption);
+} else {
+    ensurePayloadLogFilterOption();
 }
 
 // =====================================================================

--- a/front/control_panel.html
+++ b/front/control_panel.html
@@ -2408,6 +2408,7 @@
 
     <!-- 引入公共JavaScript模块 -->
     <script src="./front/common.js"></script>
+    <script src="./front/antigravity_safety.js"></script>
 
 </body>
 

--- a/front/control_panel_mobile.html
+++ b/front/control_panel_mobile.html
@@ -2135,6 +2135,7 @@
 
     <!-- 引入公共JavaScript模块 -->
     <script src="./front/common.js"></script>
+    <script src="./front/antigravity_safety.js"></script>
 </body>
 
 </html>

--- a/src/api/antigravity.py
+++ b/src/api/antigravity.py
@@ -117,8 +117,10 @@ async def wrap_cli_request(
     inner = copy.deepcopy(gemini_request)
     first_user_text = _extract_first_user_text(inner)
 
-    # 移除 safetySettings（CLI 不发送）
-    inner.pop("safetySettings", None)
+    # 在最终供应商请求边界决定是否发送 safetySettings。
+    # 默认配置保持历史行为（删除该字段）；启用后才按阈值/模型规则发送。
+    from src.api.antigravity_safety import apply_antigravity_safety_config
+    await apply_antigravity_safety_config(inner, model)
 
     # 注入 sessionId
     session_id = str(inner.get("sessionId") or "").strip()
@@ -190,6 +192,33 @@ def build_antigravity_headers(
 def _is_retryable_status(status_code: int, disable_error_codes: List[int]) -> bool:
     """统一判断是否属于可重试状态码。"""
     return status_code in (429, 503) or status_code in disable_error_codes
+
+
+def _log_outbound_payload(
+    *,
+    transport: str,
+    target_url: str,
+    model_name: str,
+    attempt: int,
+    payload: Dict[str, Any],
+) -> None:
+    """在 HTTP 发送前记录实际 JSON 请求体。
+
+    这里只记录 body，不记录 Authorization 等请求头。调用后同一个 ``payload`` 对象会直接
+    交给 httpx，因此 Payload check 展示的是 safety 规则、project 切换、requestId、labels、
+    toolConfig 等所有修改完成后的真实出站请求体。
+    """
+    try:
+        serialized = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    except Exception as exc:
+        # Payload 日志失败不能阻止真实请求继续发送。
+        log.error(f"[PAYLOAD-ERROR] failed to serialize outbound payload: {exc}")
+        return
+
+    log.info(
+        f"[PAYLOAD] transport={transport} attempt={attempt} model={model_name} "
+        f"url={target_url} body={serialized}"
+    )
 
 
 async def _switch_credential_for_retry(
@@ -284,7 +313,7 @@ async def stream_request(
     retry_interval = retry_config["retry_interval"]
 
     DISABLE_ERROR_CODES = await get_auto_ban_error_codes()  # 禁用凭证的错误码
-    last_error_response = None  # 记录最后一次的错误响应
+    last_error_response = None  # 记录最后一次错误响应
     next_cred_task = None  # 预热的下一个凭证任务
 
     # 内部函数：快速更新凭证(只更新token和project_id,避免重建整个请求)
@@ -321,6 +350,14 @@ async def stream_request(
         need_retry = False  # 标记是否需要重试
 
         try:
+            # 在本次实际 HTTP 请求发送前记录最终请求体对象。
+            _log_outbound_payload(
+                transport="stream",
+                target_url=target_url,
+                model_name=model_name,
+                attempt=attempt + 1,
+                payload=final_payload,
+            )
             async for chunk in stream_post_async(
                 url=target_url,
                 body=final_payload,
@@ -560,7 +597,7 @@ async def non_stream_request(
     retry_interval = retry_config["retry_interval"]
 
     DISABLE_ERROR_CODES = await get_auto_ban_error_codes()  # 禁用凭证的错误码
-    last_error_response = None  # 记录最后一次的错误响应
+    last_error_response = None  # 记录最后一次错误响应
     next_cred_task = None  # 预热的下一个凭证任务
 
     # 内部函数：快速更新凭证(只更新token和project_id,避免重建整个请求)
@@ -596,6 +633,14 @@ async def non_stream_request(
         need_retry = False  # 标记是否需要重试
         
         try:
+            # 在本次实际 HTTP 请求发送前记录最终请求体对象。
+            _log_outbound_payload(
+                transport="nonstream",
+                target_url=target_url,
+                model_name=model_name,
+                attempt=attempt + 1,
+                payload=final_payload,
+            )
             response = await post_async(
                 url=target_url,
                 json=final_payload,

--- a/src/api/antigravity_safety.py
+++ b/src/api/antigravity_safety.py
@@ -1,0 +1,282 @@
+"""Antigravity safetySettings 兼容性控制。
+
+本模块只负责最终请求边界上的发送决策：是否向 Google Antigravity / Cloud Code
+发送 safetySettings。它不会改写 ``normalize_antigravity_request`` 生成的 category
+列表，只应用配置的 threshold 和按模型排除规则。
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+from log import log
+
+VALID_SAFETY_THRESHOLDS = {"OFF", "BLOCK_NONE"}
+RULE_MODE_EXCLUDE_ALL = "exclude_all"
+RULE_MODE_FILTER_CATEGORIES = "filter_categories"
+VALID_RULE_MODES = {RULE_MODE_EXCLUDE_ALL, RULE_MODE_FILTER_CATEGORIES}
+
+
+def normalize_model_id(model: Any) -> str:
+    """规范化 Antigravity 模型 ID，用于规则精确匹配。"""
+    return str(model or "").strip().lower()
+
+
+def canonicalize_model_option(model: Any) -> str:
+    """将 UI/本地别名统一为最终发送时使用的模型 ID。
+
+    fetchAvailableModels 返回的模型通常已经是 canonical ID。这里仅移除本地功能前缀，
+    并规范化模型列表中的 Claude 便捷别名；Gemini 的 provider route 映射仍由聊天转换器负责。
+    """
+    from src.utils import get_base_model_from_feature_model
+
+    value = normalize_model_id(get_base_model_from_feature_model(str(model or "").strip()))
+    if not value:
+        return ""
+
+    if "claude" in value:
+        if "opus" in value:
+            return "claude-opus-4-6-thinking"
+        if "sonnet" in value:
+            return "claude-sonnet-4-6"
+        if "haiku" in value:
+            return "gemini-2.5-flash"
+        return "claude-sonnet-4-6"
+
+    return value
+
+
+def get_existing_safety_settings_for_model(model: Any) -> List[Dict[str, Any]]:
+    """返回 normalizer 当前实际使用的 safetySettings 列表副本。"""
+    from src.converter.antigravity_fix import DEFAULT_SAFETY_SETTINGS, LITE_SAFETY_SETTINGS
+
+    canonical_model = normalize_model_id(model)
+    source = (
+        LITE_SAFETY_SETTINGS
+        if "gemini-2.5-flash-lite" in canonical_model
+        else DEFAULT_SAFETY_SETTINGS
+    )
+    return deepcopy(source)
+
+
+def get_existing_safety_categories_for_model(model: Any) -> List[str]:
+    """返回仓库现有按模型 safetySettings 列表中的 category 名称。"""
+    return [
+        str(item.get("category") or "").strip()
+        for item in get_existing_safety_settings_for_model(model)
+        if isinstance(item, dict) and str(item.get("category") or "").strip()
+    ]
+
+
+def get_all_existing_safety_categories() -> List[str]:
+    """按稳定顺序返回 gcli2api 当前定义的全部 category。"""
+    from src.converter.antigravity_fix import DEFAULT_SAFETY_SETTINGS, LITE_SAFETY_SETTINGS
+
+    result: List[str] = []
+    seen = set()
+    for item in [*DEFAULT_SAFETY_SETTINGS, *LITE_SAFETY_SETTINGS]:
+        if not isinstance(item, dict):
+            continue
+        category = str(item.get("category") or "").strip()
+        if category and category not in seen:
+            seen.add(category)
+            result.append(category)
+    return result
+
+
+def apply_threshold(
+    settings: Sequence[Dict[str, Any]], threshold: str
+) -> List[Dict[str, Any]]:
+    """复制 settings，仅修改 threshold，不改变 category。"""
+    normalized_threshold = str(threshold or "").strip().upper()
+    if normalized_threshold not in VALID_SAFETY_THRESHOLDS:
+        normalized_threshold = "BLOCK_NONE"
+
+    result: List[Dict[str, Any]] = []
+    for setting in settings:
+        if not isinstance(setting, dict):
+            continue
+        item = deepcopy(setting)
+        item["threshold"] = normalized_threshold
+        result.append(item)
+    return result
+
+
+def find_model_rule(rules: Any, model: str) -> Optional[Dict[str, Any]]:
+    """按 canonical model ID 精确查找规则，不做子串或通配符匹配。"""
+    if not isinstance(rules, list):
+        return None
+
+    target = normalize_model_id(model)
+    if not target:
+        return None
+
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if normalize_model_id(rule.get("model")) == target:
+            return rule
+    return None
+
+
+def apply_model_rule(
+    settings: Sequence[Dict[str, Any]], rule: Optional[Dict[str, Any]]
+) -> Optional[List[Dict[str, Any]]]:
+    """应用单个模型规则。
+
+    返回 ``None`` 表示应完全移除 safetySettings 字段。过滤后为空时也统一返回 ``None``，
+    避免发送 ``safetySettings: []`` 来代替真正的字段省略。
+    """
+    if not rule:
+        return [deepcopy(item) for item in settings if isinstance(item, dict)]
+
+    mode = rule.get("mode")
+    if mode == RULE_MODE_EXCLUDE_ALL:
+        return None
+
+    if mode != RULE_MODE_FILTER_CATEGORIES:
+        return [deepcopy(item) for item in settings if isinstance(item, dict)]
+
+    excluded = {
+        str(category).strip()
+        for category in (rule.get("excluded_categories") or [])
+        if str(category).strip()
+    }
+    filtered = [
+        deepcopy(item)
+        for item in settings
+        if isinstance(item, dict) and str(item.get("category") or "").strip() not in excluded
+    ]
+    return filtered or None
+
+
+def validate_model_rules(
+    rules: Any,
+    allowed_categories: Iterable[str],
+    *,
+    max_rules: int = 200,
+) -> List[Dict[str, Any]]:
+    """校验并规范化需要持久化的模型规则数组。
+
+    返回值可直接整体保存为唯一规则来源。重复模型会直接拒绝，避免 UI 删除/编辑后留下
+    含糊的运行时状态；排除的 category 也会按该 canonical model 的现有 safetySettings
+    列表校验，避免保存实际不会生效的规则。
+    """
+    if not isinstance(rules, list):
+        raise ValueError("Antigravity safety model rules must be a list")
+    if len(rules) > max_rules:
+        raise ValueError(f"Antigravity safety model rules cannot exceed {max_rules} entries")
+
+    allowed = {str(category).strip() for category in allowed_categories if str(category).strip()}
+    seen_models = set()
+    normalized: List[Dict[str, Any]] = []
+
+    for index, raw_rule in enumerate(rules):
+        if not isinstance(raw_rule, dict):
+            raise ValueError(f"Safety model rule #{index + 1} must be an object")
+
+        model = canonicalize_model_option(raw_rule.get("model"))
+        if not model:
+            raise ValueError(f"Safety model rule #{index + 1} has an empty model")
+        if len(model) > 200:
+            raise ValueError(f"Safety model rule #{index + 1} model is too long")
+        if model in seen_models:
+            raise ValueError(f"Duplicate Antigravity safety model rule: {model}")
+        seen_models.add(model)
+
+        mode = str(raw_rule.get("mode") or "").strip()
+        if mode not in VALID_RULE_MODES:
+            raise ValueError(f"Invalid safety model rule mode for {model}: {mode}")
+
+        excluded_raw = raw_rule.get("excluded_categories") or []
+        if not isinstance(excluded_raw, list):
+            raise ValueError(f"excluded_categories for {model} must be a list")
+
+        model_allowed = set(get_existing_safety_categories_for_model(model))
+        excluded: List[str] = []
+        excluded_seen = set()
+        for raw_category in excluded_raw:
+            category = str(raw_category or "").strip()
+            if not category:
+                continue
+            if category not in allowed:
+                raise ValueError(f"Unknown safety category for {model}: {category}")
+            if category not in model_allowed:
+                raise ValueError(f"Safety category is not used by {model}: {category}")
+            if category not in excluded_seen:
+                excluded_seen.add(category)
+                excluded.append(category)
+
+        if mode == RULE_MODE_EXCLUDE_ALL:
+            excluded = []
+
+        normalized.append(
+            {
+                "model": model,
+                "mode": mode,
+                "excluded_categories": excluded,
+            }
+        )
+
+    return normalized
+
+
+async def apply_antigravity_safety_config(inner: Dict[str, Any], model: str) -> None:
+    """将 Antigravity safety 配置应用到最终 inner request。
+
+    必须在模型规范化完成后、最终发送边界（当前为 ``wrap_cli_request``）调用，确保抗截断、
+    假流式等本地变体和别名都使用同一个 canonical outbound model 规则。
+    """
+    from config import (
+        get_antigravity_safety_model_rules,
+        get_antigravity_safety_model_rules_enabled,
+        get_antigravity_safety_settings_enabled,
+        get_antigravity_safety_threshold,
+    )
+
+    canonical_model = normalize_model_id(model)
+
+    if not await get_antigravity_safety_settings_enabled():
+        inner.pop("safetySettings", None)
+        log.debug(
+            f"[ANTIGRAVITY SAFETY] model={canonical_model or model} action=omit reason=global_disabled"
+        )
+        return
+
+    current_settings = inner.get("safetySettings")
+    if not isinstance(current_settings, list) or not current_settings:
+        # 对于现有 normalizer 没有生成 safetySettings 的请求路径（例如图片生成），
+        # 不在这里额外构造 category 列表。
+        inner.pop("safetySettings", None)
+        log.debug(
+            f"[ANTIGRAVITY SAFETY] model={canonical_model or model} action=omit reason=no_existing_settings"
+        )
+        return
+
+    threshold = await get_antigravity_safety_threshold()
+    effective_settings = apply_threshold(current_settings, threshold)
+
+    matched_rule: Optional[Dict[str, Any]] = None
+    if await get_antigravity_safety_model_rules_enabled():
+        rules = await get_antigravity_safety_model_rules()
+        matched_rule = find_model_rule(rules, canonical_model)
+        effective_settings = apply_model_rule(effective_settings, matched_rule)
+
+    if effective_settings:
+        inner["safetySettings"] = effective_settings
+        excluded_count = len(current_settings) - len(effective_settings)
+        log.debug(
+            f"[ANTIGRAVITY SAFETY] model={canonical_model or model} action=send "
+            f"threshold={threshold} categories={len(effective_settings)} excluded={excluded_count}"
+        )
+    else:
+        inner.pop("safetySettings", None)
+        reason = (
+            "model_exclude_all"
+            if matched_rule and matched_rule.get("mode") == RULE_MODE_EXCLUDE_ALL
+            else "all_categories_filtered"
+        )
+        log.debug(
+            f"[ANTIGRAVITY SAFETY] model={canonical_model or model} action=omit reason={reason}"
+        )

--- a/src/converter/antigravity_fix.py
+++ b/src/converter/antigravity_fix.py
@@ -10,6 +10,45 @@ from typing import Any, Dict, Optional
 from log import log
 from src.converter.thoughtSignature_fix import SKIP_THOUGHT_SIGNATURE_VALIDATOR
 
+# 客户端 Gemini 别名到 Antigravity provider model ID 的唯一映射来源。
+# 聊天请求直接使用该映射；Safety 面板只反向读取它生成显示名称。
+ANTIGRAVITY_CHAT_MODEL_MAP = {
+    "gemini-3.1-pro-high": "gemini-pro-agent",
+}
+
+
+def map_antigravity_chat_model(model: Any) -> str:
+    """将客户端模型名称映射为实际发送给 Antigravity 的 provider model ID。"""
+    value = str(model or "").strip().lower()
+    return ANTIGRAVITY_CHAT_MODEL_MAP.get(value, value)
+
+
+def get_antigravity_safety_display_model(provider_model: Any) -> str:
+    """根据聊天路由映射生成 Safety 面板的模型显示名称。
+
+    该函数只影响显示，规则内部仍保存 provider ID。显示时会移除 ``-high`` 等路由后缀，
+    因此 ``gemini-3.1-pro-high -> gemini-pro-agent`` 会显示为 ``gemini-3.1-pro``。
+    """
+    provider = str(provider_model or "").strip().lower()
+    if not provider:
+        return ""
+
+    alias = next((
+        source
+        for source, target in ANTIGRAVITY_CHAT_MODEL_MAP.items()
+        if str(target or "").strip().lower() == provider
+    ), "")
+    if not alias:
+        return provider
+
+    display = str(alias).strip().lower()
+    for suffix in ("-high", "-low", "-search"):
+        if display.endswith(suffix):
+            display = display[:-len(suffix)]
+            break
+    return display or provider
+
+
 # ==================== Gemini API 配置 ====================
 
 DEFAULT_SAFETY_SETTINGS = [
@@ -600,15 +639,15 @@ def _normalize_antigravity_request(
     if "gemini" in model.lower():
         original_model = model
 
-        # 兼容旧的客户端别名：Antigravity 后端的 Gemini 3.1 Pro High
-        # 实际使用 gemini-pro-agent 作为模型 ID。
-        if model.lower() == "gemini-3.1-pro-high":
-            model = "gemini-pro-agent"
+        # 客户端模型别名统一由 ANTIGRAVITY_CHAT_MODEL_MAP 管理。
+        mapped_model = map_antigravity_chat_model(model)
+        if mapped_model != model.lower():
+            model = mapped_model
             log.debug(f"[ANTIGRAVITY] 映射模型: {original_model} -> {model}")
 
-        # Antigravity uses the Gemini 3.x model route/name to select thinking depth.
-        # Do not send thinkingLevel/thinkingBudget because they can conflict with that route.
-        # Keep includeThoughts so reasoning is still returned to the frontend when enabled.
+        # Antigravity 通过 Gemini 3.x 的模型 route/name 决定思考深度。
+        # 不发送 thinkingLevel/thinkingBudget，避免与该路由冲突；保留 includeThoughts，
+        # 以便启用时仍可向前端返回推理内容。
         if "gemini-3" in original_model.lower():
             thinking_config = generation_config.setdefault("thinkingConfig", {})
             thinking_config.pop("thinkingBudget", None)

--- a/src/panel/config_routes.py
+++ b/src/panel/config_routes.py
@@ -22,8 +22,6 @@ router = APIRouter(prefix="/config", tags=["config"])
 async def get_config(token: str = Depends(verify_panel_token)):
     """获取当前配置"""
     try:
-
-
         # 读取当前配置（包括环境变量和TOML文件中的配置）
         current_config = {}
 
@@ -60,6 +58,12 @@ async def get_config(token: str = Depends(verify_panel_token)):
         current_config["antigravity_stream2nostream"] = await config.get_antigravity_stream2nostream()
         current_config["antigravity_switch_credential_enabled"] = await config.get_antigravity_switch_credential_enabled()
 
+        # Antigravity safetySettings兼容性配置
+        current_config["antigravity_safety_settings_enabled"] = await config.get_antigravity_safety_settings_enabled()
+        current_config["antigravity_safety_threshold"] = await config.get_antigravity_safety_threshold()
+        current_config["antigravity_safety_model_rules_enabled"] = await config.get_antigravity_safety_model_rules_enabled()
+        current_config["antigravity_safety_model_rules"] = await config.get_antigravity_safety_model_rules()
+
         # 保活配置
         current_config["keepalive_url"] = await config.get_keepalive_url()
         current_config["keepalive_interval"] = await config.get_keepalive_interval()
@@ -90,11 +94,73 @@ async def get_config(token: str = Depends(verify_panel_token)):
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get("/antigravity-safety-options")
+async def get_antigravity_safety_options(token: str = Depends(verify_panel_token)):
+    """返回用于控制面板的 canonical Antigravity 模型和现有 safety 类别。
+
+    模型列表优先来自 Google fetchAvailableModels。已保存但当前未返回的模型规则
+    仍会保留在 categories_by_model 中，避免临时模型列表变化导致配置被误删。
+    """
+    from src.api.antigravity import fetch_available_models
+    from src.api.antigravity_safety import (
+        canonicalize_model_option,
+        get_existing_safety_categories_for_model,
+        get_all_existing_safety_categories,
+    )
+    from src.converter.antigravity_fix import get_antigravity_safety_display_model
+
+    try:
+        fetched = await fetch_available_models()
+    except Exception as e:
+        log.warning(f"获取Antigravity safety模型选项失败，将保留已保存规则: {e}")
+        fetched = []
+
+    models = []
+    seen = set()
+    for item in fetched:
+        raw_id = item.get("id") if isinstance(item, dict) else ""
+        model_id = canonicalize_model_option(raw_id)
+        if model_id and model_id not in seen:
+            seen.add(model_id)
+            models.append(model_id)
+
+    # 已保存的规则不能因为当前 credential/model fetch 暂时不可用而消失。
+    saved_rules = await config.get_antigravity_safety_model_rules()
+    saved_models = []
+    for rule in saved_rules:
+        if not isinstance(rule, dict):
+            continue
+        model_id = canonicalize_model_option(rule.get("model"))
+        if model_id and model_id not in saved_models:
+            saved_models.append(model_id)
+
+    categories_by_model = {}
+    for model_id in [*models, *saved_models]:
+        if model_id not in categories_by_model:
+            categories_by_model[model_id] = get_existing_safety_categories_for_model(model_id)
+
+    # 这里只生成显示名称：反向读取真实聊天路由映射。规则值仍保存
+    # fetchAvailableModels 返回的 canonical provider ID，因此修改聊天路由后，
+    # Safety 面板显示会自动同步，不需要维护第二份硬编码模型映射。
+    model_labels = {
+        model_id: get_antigravity_safety_display_model(model_id)
+        for model_id in [*models, *saved_models]
+    }
+
+    return JSONResponse(
+        content={
+            "models": models,
+            "categories_by_model": categories_by_model,
+            "default_categories": get_all_existing_safety_categories(),
+            "model_labels": model_labels,
+        }
+    )
+
+
 @router.post("/save")
 async def save_config(request: ConfigSaveRequest, token: str = Depends(verify_panel_token)):
     """保存配置"""
     try:
-
         new_config = request.config
 
         log.debug(f"收到的配置数据: {list(new_config.keys())}")
@@ -147,6 +213,35 @@ async def save_config(request: ConfigSaveRequest, token: str = Depends(verify_pa
             if not isinstance(new_config["antigravity_switch_credential_enabled"], bool):
                 raise HTTPException(status_code=400, detail="Antigravity切换凭证开关必须是布尔值")
 
+        # Antigravity safetySettings 配置严格验证。
+        if "antigravity_safety_settings_enabled" in new_config:
+            if not isinstance(new_config["antigravity_safety_settings_enabled"], bool):
+                raise HTTPException(status_code=400, detail="Antigravity safetySettings开关必须是布尔值")
+
+        if "antigravity_safety_threshold" in new_config:
+            threshold = str(new_config["antigravity_safety_threshold"] or "").strip().upper()
+            if threshold not in {"OFF", "BLOCK_NONE"}:
+                raise HTTPException(status_code=400, detail="Antigravity safety threshold只能是OFF或BLOCK_NONE")
+            new_config["antigravity_safety_threshold"] = threshold
+
+        if "antigravity_safety_model_rules_enabled" in new_config:
+            if not isinstance(new_config["antigravity_safety_model_rules_enabled"], bool):
+                raise HTTPException(status_code=400, detail="Antigravity safety模型规则开关必须是布尔值")
+
+        if "antigravity_safety_model_rules" in new_config:
+            from src.api.antigravity_safety import (
+                get_all_existing_safety_categories,
+                validate_model_rules,
+            )
+
+            try:
+                new_config["antigravity_safety_model_rules"] = validate_model_rules(
+                    new_config["antigravity_safety_model_rules"],
+                    get_all_existing_safety_categories(),
+                )
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e))
+
         # 验证保活配置
         if "keepalive_url" in new_config:
             if not isinstance(new_config["keepalive_url"], str):
@@ -188,7 +283,8 @@ async def save_config(request: ConfigSaveRequest, token: str = Depends(verify_pa
         # 获取环境变量锁定的配置键
         env_locked_keys = get_env_locked_keys()
 
-        # 直接使用存储适配器保存配置
+        # 直接使用存储适配器保存配置。model rules作为单一数组整体替换，
+        # 删除UI行后不会留下额外的blacklist/map/tombstone状态。
         storage_adapter = await get_storage_adapter()
         for key, value in new_config.items():
             if key not in env_locked_keys:

--- a/version.txt
+++ b/version.txt
@@ -1,4 +1,4 @@
-full_hash=9d6e0accd1758b51bd6e9254f106c28bc8c9b661
-short_hash=9d6e0ac
-message=Revert "新版抗截断"
-date=2026-08-31 08:08:54 +0800
+full_hash=4df63ece72811cc61cc159345dd3cc1acd53e563
+short_hash=4df63ec
+message=ui: 优化 Safety 模型规则列表
+date=2026-09-01 08:48:16 +0000


### PR DESCRIPTION
## 中文说明

### 目的

本 PR 为 Antigravity 请求增加可配置的 `safetySettings` 兼容控制，并提供一个用于确认最终真实出站 JSON 请求体的“请求体检查”视图。目标是在不改变默认历史行为的前提下，让不同 Antigravity 模型可以按实际兼容情况调整 safety category，同时方便排查模型路由、规则过滤和最终请求体是否符合预期。

### 主要改动

#### 1. Antigravity safetySettings 运行时控制

- 默认保持现有行为：功能未启用时，在最终发送前移除 `safetySettings`，因此旧配置不会因为升级自动改变请求行为。
- 启用后复用仓库现有的 Default / Lite safety category 列表，不额外维护第二套 category 来源。
- 支持全局 threshold：`BLOCK_NONE` / `OFF`。
- 支持按 canonical model 精确配置两种规则：
  - 移除整个 `safetySettings` 字段；
  - 仅过滤指定 category。
- 规则在最终 Antigravity provider 边界应用，因此抗截断、假流式等本地 feature model / alias 会继承实际发送模型的同一规则。
- 若某条过滤规则最终移除了全部 category，则直接省略 `safetySettings`，不会发送空数组。

#### 2. 控制面板 UI

- 在桌面版和移动版控制面板的 **Antigravity 兼容设置区域** 中，紧接在 `Antigravity切换凭证` 配置之后插入新的 `Antigravity safetySettings 兼容性控制` 面板。
- 面板提供：
  - 是否向 Antigravity 发送 `safetySettings`；
  - threshold 选择；
  - `Model Safety Overrides` 开关；
  - 按模型添加、编辑、删除规则。
- 模型列表来自 Antigravity `fetchAvailableModels`，规则内部仍绑定 Google 返回的 canonical model ID。
- Safety 面板的友好显示名复用现有聊天模型映射反向解析，不新增第二份 provider model mapping。
- 对 Lite 模型不支持的 category，UI 会以红色标记并锁定，表示这些 category 本来就不会发送。
- 已保存但暂时不再出现在 `fetchAvailableModels` 中的模型规则仍会保留并可删除，避免模型列表临时变化导致配置丢失。
- 当已添加规则达到 2 条及以上时，规则区域改为局部滚动列表，避免整个配置页持续变长；同时显示 `搜索已添加模型…` 搜索框，可按 canonical ID 或显示名过滤已创建规则，并显示匹配计数。搜索仅影响显示，不修改已保存配置。

#### 3. 配置保存流程

- Safety 配置直接合并进控制面板已有的公共 `saveConfig()` 对象，与其他设置通过同一个 `/config/save` 请求保存。
- 不再临时替换全局 `window.fetch`，也不再包装 `saveConfig()`，避免并发保存时相互影响。
- 仍在正常 `loadConfig()` 完成后刷新 Safety 模型选项和面板状态。

#### 4. 请求体检查

- 在 Antigravity stream / non-stream 的每次真实 HTTP 发送前，记录当前实际使用的 `final_payload` JSON body。
- 日志带 `[PAYLOAD]` 标记，并继续使用仓库现有 logger；不记录 `Authorization` 请求头。
- 控制面板日志筛选器新增 `请求体检查`，`[PAYLOAD]` 行不会混入普通 All / Info / Warning 等显示中。
- `contents` 会按 message / parts 层级展开，便于查看多轮对话；较小对象仍保持紧凑显示。
- 该视图用于确认 safety rule、model route、project 切换、requestId、labels、toolConfig 等最终修改后的真实出站请求体。

### 涉及文件

- 新增：`src/api/antigravity_safety.py`
- 新增：`front/antigravity_safety.js`
- 修改：`config.py`
- 修改：`src/api/antigravity.py`
- 修改：`src/converter/antigravity_fix.py`
- 修改：`src/panel/config_routes.py`
- 修改：`front/common.js`
- 修改：`front/control_panel.html`
- 修改：`front/control_panel_mobile.html`

---

## English Description

### Purpose

This PR adds configurable `safetySettings` compatibility controls for Antigravity requests and a request-body inspector for verifying the actual final outbound JSON payload. The goal is to support model-specific safety compatibility without changing the repository's historical default behavior, while making it easier to diagnose model routing, safety filtering, and the exact payload sent to Antigravity.

### Main changes

#### 1. Runtime Antigravity safetySettings controls

- Preserves the existing default behavior: when the feature is disabled, `safetySettings` is removed before the final provider request, so upgrading does not silently change existing request behavior.
- Reuses the repository's existing Default / Lite safety category lists instead of introducing a second category source.
- Adds a global threshold selector supporting `BLOCK_NONE` and `OFF`.
- Adds exact per-canonical-model rules with two modes:
  - omit the entire `safetySettings` field;
  - filter selected categories only.
- Rules are applied at the final Antigravity provider boundary, so local feature-model variants and aliases such as anti-truncation or pseudo-streaming inherit the same rule as the actual outbound canonical model.
- If filtering removes every category, the field is omitted rather than sending `safetySettings: []`.

#### 2. Control panel UI

- Adds a new `Antigravity safetySettings` compatibility panel to both desktop and mobile control panels, inside the **Antigravity compatibility settings section**, directly after the existing `Antigravity switch credential` setting.
- The panel provides:
  - a global toggle for sending `safetySettings`;
  - threshold selection;
  - a `Model Safety Overrides` toggle;
  - per-model rule creation, editing, and deletion.
- The model list comes from Antigravity `fetchAvailableModels`; persisted rules remain bound to the canonical model IDs returned by Google.
- Friendly model labels are derived by reversing the existing chat-model mapping, avoiding a second provider-model mapping table.
- Categories unsupported by Lite models are shown in red and locked, indicating that they are already absent from that model's outbound safety list.
- Persisted rules for models temporarily missing from `fetchAvailableModels` remain visible and removable instead of being silently dropped.
- With 2 or more created model rules, the rule area becomes a locally scrollable list so the whole settings page does not keep growing. A dedicated `搜索已添加模型…` search field filters already-created rules by canonical model ID or display label and shows match counts. Filtering is display-only and never mutates persisted rules.

#### 3. Configuration save flow

- Safety settings are merged directly into the existing common `saveConfig()` object and saved together with all other settings through the same `/config/save` request.
- Removes the previous temporary wrapping of global `window.fetch` and `saveConfig()`, avoiding interference between overlapping save operations.
- The Safety UI still refreshes its model options and state after the normal `loadConfig()` flow completes.

#### 4. Request-body inspector

- Immediately before every real Antigravity stream or non-stream HTTP send, the code logs the exact JSON body object used as `final_payload`.
- Entries are tagged with `[PAYLOAD]` and use the repository's existing logger; Authorization headers are not logged.
- The control-panel log filter gains a dedicated `请求体检查` view. `[PAYLOAD]` lines are excluded from normal All / Info / Warning views to keep regular logs readable.
- Conversation `contents` are expanded by message / parts hierarchy for easier multi-turn inspection, while small unrelated objects remain compact.
- This is intended to verify the real outbound request after safety rules, model routing, project switching, requestId, labels, toolConfig, and other final provider-boundary modifications have been applied.

### Files changed

- Added: `src/api/antigravity_safety.py`
- Added: `front/antigravity_safety.js`
- Modified: `config.py`
- Modified: `src/api/antigravity.py`
- Modified: `src/converter/antigravity_fix.py`
- Modified: `src/panel/config_routes.py`
- Modified: `front/common.js`
- Modified: `front/control_panel.html`
- Modified: `front/control_panel_mobile.html`
