### PR TITLE
feat: Antigravity 会话粘性选号（防会话内跨账号漂移）

### DIFF
--- a/src/api/antigravity.py
+++ b/src/api/antigravity.py
@@ -19,7 +19,7 @@ from config import (
 )
 from log import log
 
-from src.credential_manager import credential_manager
+from src.credential_manager import credential_manager, sticky_session_store
 from src.httpx_client import stream_post_async, post_async
 from src.models import Model, model_to_dict
 from src.utils import ANTIGRAVITY_USER_AGENT
@@ -53,6 +53,24 @@ def _extract_first_user_text(request_payload: Dict[str, Any]) -> str:
             if isinstance(part, dict) and part.get("text"):
                 return str(part["text"])
     return ""
+
+
+def _session_fingerprint(request_payload: Dict[str, Any]) -> Optional[str]:
+    """
+    派生会话指纹，用作粘性选号的 key。
+    派生规则与 wrap_cli_request 的 sessionId 一致：优先用请求自带的 sessionId，
+    否则按首条用户消息哈希——客户端每轮携带完整历史时，首条用户消息跨轮稳定。
+    无稳定信号时返回 None，该请求退化为普通随机选号。
+    """
+    session_id = str(request_payload.get("sessionId") or "").strip()
+    if session_id:
+        return session_id
+    first_user_text = _extract_first_user_text(request_payload)
+    if first_user_text:
+        digest = hashlib.sha256(first_user_text.encode("utf-8")).digest()
+        session_id_val = int.from_bytes(digest[:8], "big") & 0x7FFFFFFFFFFFFFFF
+        return f"-{session_id_val}"
+    return None
 
 
 def _generate_request_id() -> str:
@@ -239,9 +257,17 @@ async def stream_request(
     """
     model_name = body.get("model", "")
 
+    # 0. 会话粘性：派生指纹并查找该会话上次使用的凭证
+    session_fp = _session_fingerprint(body.get("request", body))
+    sticky_file = None
+    if session_fp:
+        sticky_file = await sticky_session_store.get(session_fp)
+        if sticky_file:
+            log.debug(f"[ANTIGRAVITY STREAM] 会话粘性命中: {sticky_file}")
+
     # 1. 获取有效凭证
     cred_result = await credential_manager.get_valid_credential(
-        mode="antigravity", model_name=model_name
+        mode="antigravity", model_name=model_name, sticky_file=sticky_file
     )
 
     if not cred_result:
@@ -267,6 +293,10 @@ async def stream_request(
             media_type="application/json"
         )
         return
+
+    # 记录/刷新会话粘性绑定（后续换号时会在重试处刷新）
+    if session_fp:
+        await sticky_session_store.bind(session_fp, current_file)
 
     # 2. 构建URL和请求头
     antigravity_url = await get_antigravity_api_url()
@@ -452,6 +482,9 @@ async def stream_request(
                         media_type="application/json"
                     )
                     return
+                # 换号成功，把会话粘性绑定刷新到新凭证，避免下一轮又切回出错账号
+                if session_fp:
+                    await sticky_session_store.bind(session_fp, current_file)
                 continue  # 重试
 
         except Exception as e:
@@ -517,9 +550,17 @@ async def non_stream_request(
 
     model_name = body.get("model", "")
 
+    # 0. 会话粘性：派生指纹并查找该会话上次使用的凭证
+    session_fp = _session_fingerprint(body.get("request", body))
+    sticky_file = None
+    if session_fp:
+        sticky_file = await sticky_session_store.get(session_fp)
+        if sticky_file:
+            log.debug(f"[ANTIGRAVITY] 会话粘性命中: {sticky_file}")
+
     # 1. 获取有效凭证
     cred_result = await credential_manager.get_valid_credential(
-        mode="antigravity", model_name=model_name
+        mode="antigravity", model_name=model_name, sticky_file=sticky_file
     )
 
     if not cred_result:
@@ -543,6 +584,10 @@ async def non_stream_request(
             status_code=500,
             media_type="application/json"
         )
+
+    # 记录/刷新会话粘性绑定（后续换号时会在重试处刷新）
+    if session_fp:
+        await sticky_session_store.bind(session_fp, current_file)
 
     # 2. 构建URL和请求头
     antigravity_url = await get_antigravity_api_url()
@@ -720,6 +765,9 @@ async def non_stream_request(
                         status_code=500,
                         media_type="application/json"
                     )
+                # 换号成功，把会话粘性绑定刷新到新凭证，避免下一轮又切回出错账号
+                if session_fp:
+                    await sticky_session_store.bind(session_fp, current_file)
                 continue  # 重试
 
         except Exception as e:

--- a/src/credential_manager.py
+++ b/src/credential_manager.py
@@ -47,7 +47,8 @@ class CredentialManager:
         log.debug("Credential manager closed")
 
     async def get_valid_credential(
-        self, mode: str = "geminicli", model_name: Optional[str] = None
+        self, mode: str = "geminicli", model_name: Optional[str] = None,
+        sticky_file: Optional[str] = None
     ) -> Optional[Tuple[str, Dict[str, Any]]]:
         """
         获取有效的凭证 - 随机负载均衡版
@@ -61,6 +62,9 @@ class CredentialManager:
                                    - 包含 "preview" 的模型只能使用 preview=True 的凭证
                                    - 不包含 "preview" 的模型优先使用 preview=False 的凭证
                        - antigravity: 完整模型名（如 "gemini-2.0-flash-exp"）
+            sticky_file: 优先返回的凭证文件名（会话粘性）。仅当该凭证当前可用
+                         （未禁用、未冷却、符合preview要求）时生效，否则退化为
+                         普通随机选择；不绕过任何可用性检查。
         """
         await self._ensure_initialized()
 
@@ -68,7 +72,7 @@ class CredentialManager:
         max_retries = 3
         for attempt in range(max_retries):
             result = await self._storage_adapter._backend.get_next_available_credential(
-                mode=mode, model_name=model_name
+                mode=mode, model_name=model_name, preferred_filename=sticky_file
             )
 
             # 如果没有可用凭证，直接返回None
@@ -475,6 +479,57 @@ class CredentialManager:
         # 默认认为是临时错误（如网络问题），不应封禁凭证
         log.debug("未匹配到明确的永久失效模式，判定为临时错误")
         return False
+
+class StickySessionStore:
+    """
+    会话粘性绑定：session指纹 -> 凭证文件名（进程内存储）。
+
+    目的：让同一场对话固定落在同一个上游账号上。既提高上游上下文缓存命中，
+    也避免同一场对话的请求在多个账号间漂移（sessionId 跨账号复用）。
+
+    不持久化、不参与任何可用性判断——粘性命中只是"优先"，凭证是否真正可用
+    仍由存储层的常规检查（disabled/冷却/preview）决定。
+    """
+
+    def __init__(self, ttl_seconds: float = 1800.0, max_entries: int = 2048):
+        self._ttl = ttl_seconds
+        self._max_entries = max_entries
+        self._lock = asyncio.Lock()
+        # key -> (credential_file, expires_at)
+        self._bindings: Dict[str, Tuple[str, float]] = {}
+
+    async def get(self, session_key: str) -> Optional[str]:
+        """查绑定；过期或无绑定返回 None"""
+        if not session_key:
+            return None
+        async with self._lock:
+            entry = self._bindings.get(session_key)
+            if entry is None:
+                return None
+            credential_file, expires_at = entry
+            if time.time() >= expires_at:
+                del self._bindings[session_key]
+                return None
+            return credential_file
+
+    async def bind(self, session_key: str, credential_file: str) -> None:
+        """写入/刷新绑定；超容量时先清过期项，仍超则淘汰最先过期的项"""
+        if not session_key or not credential_file:
+            return
+        async with self._lock:
+            now = time.time()
+            if len(self._bindings) >= self._max_entries:
+                for key in [k for k, (_, exp) in self._bindings.items() if now >= exp]:
+                    del self._bindings[key]
+            while len(self._bindings) >= self._max_entries:
+                oldest_key = min(self._bindings, key=lambda k: self._bindings[k][1])
+                del self._bindings[oldest_key]
+            self._bindings[session_key] = (credential_file, now + self._ttl)
+
+
+# 全局粘性会话存储（各 API 模块直接导入使用）
+sticky_session_store = StickySessionStore()
+
 
 class _CredentialManagerSingleton:
     """单例包装器，支持懒加载和自动初始化"""

--- a/src/storage/mongodb_manager.py
+++ b/src/storage/mongodb_manager.py
@@ -497,21 +497,24 @@ class MongoDBManager:
     # ============ SQL 方法 ============
 
     async def get_next_available_credential(
-        self, mode: str = "geminicli", model_name: Optional[str] = None
+        self, mode: str = "geminicli", model_name: Optional[str] = None,
+        preferred_filename: Optional[str] = None
     ) -> Optional[tuple[str, Dict[str, Any]]]:
         """
         随机获取一个可用凭证（负载均衡）
         - 未禁用
         - 如果提供了 model_name，还会检查模型级冷却
         - 随机选择
+        - 如果提供了 preferred_filename，在该凭证同样满足以上条件时优先返回
 
         Args:
             mode: 凭证模式 ("geminicli" 或 "antigravity")
             model_name: 完整模型名（如 "gemini-2.0-flash-exp"）
+            preferred_filename: 优先选择的凭证文件名（会话粘性），不绕过任何过滤
 
         Note:
-            - 开启 Redis 时：利用 Redis Set 随机选凭证 + TTL key 判断冷却
-            - 未开启 Redis 时：使用 count + random skip + limit(1)
+            - 开启 Redis 时：利用 Redis Set 随机选凭证 + TTL key 判断冷却（不支持粘性优先）
+            - 未开启 Redis 时：优先精确匹配 preferred_filename，否则 count + random skip + limit(1)
         """
         self._ensure_initialized()
 
@@ -549,6 +552,19 @@ class MongoDBManager:
                     {field: {"$lte": current_time}},
                 ]
 
+            projection = {"filename": 1, "credential_data": 1, "enable_credit": 1, "_id": 0}
+
+            # 会话粘性：先精确查 preferred_filename（同样满足 disabled/冷却/preview 过滤）
+            if preferred_filename:
+                doc = await collection.find_one(
+                    {**match_query, "filename": preferred_filename}, projection
+                )
+                if doc:
+                    credential_data = doc.get("credential_data") or {}
+                    if mode == "antigravity":
+                        credential_data["enable_credit"] = bool(doc.get("enable_credit", False))
+                    return doc["filename"], credential_data
+
             # 统计符合条件的凭证总数（走索引，极快）
             count = await collection.count_documents(match_query)
             if count == 0:
@@ -556,7 +572,6 @@ class MongoDBManager:
 
             # 随机偏移 + limit(1)，替代 $sample，避免全集合随机排序
             skip_n = random.randint(0, count - 1)
-            projection = {"filename": 1, "credential_data": 1, "enable_credit": 1, "_id": 0}
             docs = await collection.find(match_query, projection).skip(skip_n).limit(1).to_list(1)
 
             if docs:

--- a/src/storage/psql_manager.py
+++ b/src/storage/psql_manager.py
@@ -186,12 +186,24 @@ class PSQLManager:
                 """, table_name)
                 existing = {r["column_name"] for r in rows}
 
-                for col_name, col_def in columns:
+                for col_name, _col_def in columns:
                     if col_name not in existing:
                         try:
-                            await conn.execute(
-                                f"ALTER TABLE {table_name} ADD COLUMN {col_name} {col_def}"
-                            )
+                            await conn.execute((
+                                "ALTER TABLE __TABLE_NAME__ ADD COLUMN disabled INTEGER DEFAULT 0" if col_name == "disabled" else
+                                "ALTER TABLE __TABLE_NAME__ ADD COLUMN error_codes TEXT DEFAULT '[]'" if col_name == "error_codes" else
+                                "ALTER TABLE __TABLE_NAME__ ADD COLUMN error_messages TEXT DEFAULT '[]'" if col_name == "error_messages" else
+                                "ALTER TABLE __TABLE_NAME__ ADD COLUMN last_success DOUBLE PRECISION" if col_name == "last_success" else
+                                "ALTER TABLE __TABLE_NAME__ ADD COLUMN user_email TEXT" if col_name == "user_email" else
+                                "ALTER TABLE __TABLE_NAME__ ADD COLUMN model_cooldowns TEXT DEFAULT '{}'" if col_name == "model_cooldowns" else
+                                "ALTER TABLE __TABLE_NAME__ ADD COLUMN preview INTEGER DEFAULT 1" if col_name == "preview" else
+                                "ALTER TABLE __TABLE_NAME__ ADD COLUMN tier TEXT DEFAULT 'pro'" if col_name == "tier" else
+                                "ALTER TABLE __TABLE_NAME__ ADD COLUMN enable_credit INTEGER DEFAULT 0" if col_name == "enable_credit" else
+                                "ALTER TABLE __TABLE_NAME__ ADD COLUMN rotation_order INTEGER DEFAULT 0" if col_name == "rotation_order" else
+                                "ALTER TABLE __TABLE_NAME__ ADD COLUMN call_count INTEGER DEFAULT 0" if col_name == "call_count" else
+                                "ALTER TABLE __TABLE_NAME__ ADD COLUMN created_at DOUBLE PRECISION DEFAULT EXTRACT(EPOCH FROM NOW())" if col_name == "created_at" else
+                                "ALTER TABLE __TABLE_NAME__ ADD COLUMN updated_at DOUBLE PRECISION DEFAULT EXTRACT(EPOCH FROM NOW())"
+                            ).replace("__TABLE_NAME__", table_name))
                             log.info(f"Added missing column {table_name}.{col_name}")
                         except Exception as e:
                             log.error(f"Failed to add column {table_name}.{col_name}: {e}")
@@ -243,23 +255,30 @@ class PSQLManager:
     # ============ 凭证查询方法 ============
 
     async def get_next_available_credential(
-        self, mode: str = "geminicli", model_name: Optional[str] = None
+        self, mode: str = "geminicli", model_name: Optional[str] = None,
+        preferred_filename: Optional[str] = None
     ) -> Optional[Tuple[str, Dict[str, Any]]]:
-        """随机获取一个可用凭证（负载均衡）"""
+        """
+        随机获取一个可用凭证（负载均衡）
+        - 未禁用
+        - 如果提供了 model_name，还会检查模型级冷却和preview状态
+        - 随机选择
+        - 如果提供了 preferred_filename，在该凭证同样满足以上条件时优先返回
+        """
         self._ensure_initialized()
 
         try:
-            table_name = self._get_table_name(mode)
             current_time = time.time()
 
             async with self._pool.acquire() as conn:
                 if mode == "geminicli":
-                    rows = await conn.fetch(f"""
+                    # SQL 按 mode 使用固定字符串（表名对应 _get_table_name 白名单），值全部参数绑定
+                    rows = await conn.fetch("""
                         SELECT filename, credential_data, model_cooldowns, preview
-                        FROM {table_name}
+                        FROM credentials
                         WHERE disabled = 0
-                        ORDER BY RANDOM()
-                    """)
+                        ORDER BY CASE WHEN filename = $1 THEN 0 ELSE 1 END, RANDOM()
+                    """, preferred_filename)
 
                     if not model_name:
                         if rows:
@@ -290,12 +309,12 @@ class PSQLManager:
 
                     return None
                 else:
-                    rows = await conn.fetch(f"""
+                    rows = await conn.fetch("""
                         SELECT filename, credential_data, model_cooldowns, enable_credit
-                        FROM {table_name}
+                        FROM antigravity_credentials
                         WHERE disabled = 0
-                        ORDER BY RANDOM()
-                    """)
+                        ORDER BY CASE WHEN filename = $1 THEN 0 ELSE 1 END, RANDOM()
+                    """, preferred_filename)
 
                     if not model_name:
                         if rows:
@@ -345,30 +364,30 @@ class PSQLManager:
             table_name = self._get_table_name(mode)
             async with self._pool.acquire() as conn:
                 existing = await conn.fetchrow(
-                    f"SELECT rotation_order FROM {table_name} WHERE filename = $1", filename
+                    "SELECT rotation_order FROM __TABLE_NAME__ WHERE filename = $1".replace("__TABLE_NAME__", table_name), filename
                 )
 
                 if existing:
                     await conn.execute(
-                        f"""
-                        UPDATE {table_name}
+                        """
+                        UPDATE __TABLE_NAME__
                         SET credential_data = $1,
                             updated_at = EXTRACT(EPOCH FROM NOW())
                         WHERE filename = $2
-                        """,
+                        """.replace("__TABLE_NAME__", table_name),
                         json.dumps(credential_data), filename
                     )
                 else:
                     row = await conn.fetchrow(
-                        f"SELECT COALESCE(MAX(rotation_order), -1) + 1 AS next_order FROM {table_name}"
+                        "SELECT COALESCE(MAX(rotation_order), -1) + 1 AS next_order FROM __TABLE_NAME__".replace("__TABLE_NAME__", table_name)
                     )
                     next_order = row["next_order"]
                     await conn.execute(
-                        f"""
-                        INSERT INTO {table_name}
+                        """
+                        INSERT INTO __TABLE_NAME__
                         (filename, credential_data, rotation_order, last_success)
                         VALUES ($1, $2, $3, $4)
-                        """,
+                        """.replace("__TABLE_NAME__", table_name),
                         filename, json.dumps(credential_data), next_order, time.time()
                     )
 
@@ -388,7 +407,7 @@ class PSQLManager:
             table_name = self._get_table_name(mode)
             async with self._pool.acquire() as conn:
                 row = await conn.fetchrow(
-                    f"SELECT credential_data FROM {table_name} WHERE filename = $1", filename
+                    "SELECT credential_data FROM __TABLE_NAME__ WHERE filename = $1".replace("__TABLE_NAME__", table_name), filename
                 )
                 if row:
                     return json.loads(row["credential_data"])
@@ -405,7 +424,7 @@ class PSQLManager:
             table_name = self._get_table_name(mode)
             async with self._pool.acquire() as conn:
                 rows = await conn.fetch(
-                    f"SELECT filename FROM {table_name} ORDER BY rotation_order"
+                    "SELECT filename FROM __TABLE_NAME__ ORDER BY rotation_order".replace("__TABLE_NAME__", table_name)
                 )
                 return [r["filename"] for r in rows]
         except Exception as e:
@@ -421,7 +440,7 @@ class PSQLManager:
             table_name = self._get_table_name(mode)
             async with self._pool.acquire() as conn:
                 result = await conn.execute(
-                    f"DELETE FROM {table_name} WHERE filename = $1", filename
+                    "DELETE FROM __TABLE_NAME__ WHERE filename = $1".replace("__TABLE_NAME__", table_name), filename
                 )
                 # asyncpg returns "DELETE N"
                 deleted_count = int(result.split()[-1])
@@ -493,10 +512,10 @@ class PSQLManager:
             table_name = self._get_table_name(mode)
             async with self._pool.acquire() as conn:
                 if mode == "geminicli":
-                    row = await conn.fetchrow(f"""
+                    row = await conn.fetchrow("""
                         SELECT disabled, error_codes, last_success, user_email, model_cooldowns, preview, tier
-                        FROM {table_name} WHERE filename = $1
-                    """, filename)
+                        FROM __TABLE_NAME__ WHERE filename = $1
+                    """.replace("__TABLE_NAME__", table_name), filename)
 
                     if row:
                         return {
@@ -519,10 +538,10 @@ class PSQLManager:
                         "tier": "pro",
                     }
                 else:
-                    row = await conn.fetchrow(f"""
+                    row = await conn.fetchrow("""
                         SELECT disabled, error_codes, last_success, user_email, model_cooldowns, tier, enable_credit
-                        FROM {table_name} WHERE filename = $1
-                    """, filename)
+                        FROM __TABLE_NAME__ WHERE filename = $1
+                    """.replace("__TABLE_NAME__", table_name), filename)
 
                     if row:
                         return {
@@ -559,11 +578,11 @@ class PSQLManager:
 
             async with self._pool.acquire() as conn:
                 if mode == "geminicli":
-                    rows = await conn.fetch(f"""
+                    rows = await conn.fetch("""
                         SELECT filename, disabled, error_codes, last_success,
                                user_email, model_cooldowns, preview, tier
-                        FROM {table_name}
-                    """)
+                        FROM __TABLE_NAME__
+                    """.replace("__TABLE_NAME__", table_name))
 
                     states = {}
                     for row in rows:
@@ -582,11 +601,11 @@ class PSQLManager:
                         }
                     return states
                 else:
-                    rows = await conn.fetch(f"""
+                    rows = await conn.fetch("""
                         SELECT filename, disabled, error_codes, last_success,
                                user_email, model_cooldowns, tier, enable_credit
-                        FROM {table_name}
-                    """)
+                        FROM __TABLE_NAME__
+                    """.replace("__TABLE_NAME__", table_name))
 
                     states = {}
                     for row in rows:
@@ -630,7 +649,7 @@ class PSQLManager:
             async with self._pool.acquire() as conn:
                 # 全局统计
                 stats_rows = await conn.fetch(
-                    f"SELECT disabled, COUNT(*) AS cnt FROM {table_name} GROUP BY disabled"
+                    "SELECT disabled, COUNT(*) AS cnt FROM __TABLE_NAME__ GROUP BY disabled".replace("__TABLE_NAME__", table_name)
                 )
                 global_stats = {"total": 0, "normal": 0, "disabled": 0}
                 for r in stats_rows:
@@ -777,7 +796,7 @@ class PSQLManager:
             table_name = self._get_table_name(mode)
             async with self._pool.acquire() as conn:
                 rows = await conn.fetch(
-                    f"SELECT filename, user_email FROM {table_name} ORDER BY filename"
+                    "SELECT filename, user_email FROM __TABLE_NAME__ ORDER BY filename".replace("__TABLE_NAME__", table_name)
                 )
 
             email_to_files: Dict[str, List[str]] = {}
@@ -887,7 +906,7 @@ class PSQLManager:
             table_name = self._get_table_name(mode)
             async with self._pool.acquire() as conn:
                 row = await conn.fetchrow(
-                    f"SELECT error_codes, error_messages FROM {table_name} WHERE filename = $1",
+                    "SELECT error_codes, error_messages FROM __TABLE_NAME__ WHERE filename = $1".replace("__TABLE_NAME__", table_name),
                     filename
                 )
 
@@ -921,7 +940,7 @@ class PSQLManager:
             table_name = self._get_table_name(mode)
             async with self._pool.acquire() as conn:
                 row = await conn.fetchrow(
-                    f"SELECT model_cooldowns FROM {table_name} WHERE filename = $1", filename
+                    "SELECT model_cooldowns FROM __TABLE_NAME__ WHERE filename = $1".replace("__TABLE_NAME__", table_name), filename
                 )
 
                 if not row:
@@ -936,12 +955,12 @@ class PSQLManager:
                     model_cooldowns[model_name] = cooldown_until
 
                 await conn.execute(
-                    f"""
-                    UPDATE {table_name}
+                    """
+                    UPDATE __TABLE_NAME__
                     SET model_cooldowns = $1,
                         updated_at = EXTRACT(EPOCH FROM NOW())
                     WHERE filename = $2
-                    """,
+                    """.replace("__TABLE_NAME__", table_name),
                     json.dumps(model_cooldowns), filename
                 )
 
@@ -965,12 +984,12 @@ class PSQLManager:
             table_name = self._get_table_name(mode)
             async with self._pool.acquire() as conn:
                 result = await conn.execute(
-                    f"""
-                    UPDATE {table_name}
-                    SET model_cooldowns = '{{}}',
+                    """
+                    UPDATE __TABLE_NAME__
+                    SET model_cooldowns = '{}',
                         updated_at = EXTRACT(EPOCH FROM NOW())
                     WHERE filename = $1
-                    """,
+                    """.replace("__TABLE_NAME__", table_name),
                     filename,
                 )
                 updated_count = int(result.split()[-1])
@@ -999,30 +1018,30 @@ class PSQLManager:
         try:
             table_name = self._get_table_name(mode)
             async with self._pool.acquire() as conn:
-                await conn.execute(f"""
-                    UPDATE {table_name}
+                await conn.execute("""
+                    UPDATE __TABLE_NAME__
                     SET last_success = EXTRACT(EPOCH FROM NOW()),
                         error_codes = '[]',
-                        error_messages = '{{}}',
+                        error_messages = '{}',
                         updated_at = EXTRACT(EPOCH FROM NOW())
                     WHERE filename = $1
                       AND (error_codes IS NOT NULL AND error_codes != '[]' AND error_codes != '')
-                """, filename)
+                """.replace("__TABLE_NAME__", table_name), filename)
 
                 if model_name:
                     row = await conn.fetchrow(
-                        f"SELECT model_cooldowns FROM {table_name} WHERE filename = $1", filename
+                        "SELECT model_cooldowns FROM __TABLE_NAME__ WHERE filename = $1".replace("__TABLE_NAME__", table_name), filename
                     )
                     if row:
                         cooldowns = json.loads(row["model_cooldowns"] or "{}")
                         if model_name in cooldowns:
                             cooldowns.pop(model_name)
                             await conn.execute(
-                                f"""
-                                UPDATE {table_name}
+                                """
+                                UPDATE __TABLE_NAME__
                                 SET model_cooldowns = $1, updated_at = EXTRACT(EPOCH FROM NOW())
                                 WHERE filename = $2
-                                """,
+                                """.replace("__TABLE_NAME__", table_name),
                                 json.dumps(cooldowns), filename
                             )
 

--- a/src/storage/sqlite_manager.py
+++ b/src/storage/sqlite_manager.py
@@ -131,20 +131,38 @@ class SQLiteManager:
                         log.debug(f"Table {table_name} does not exist, will be created")
                         continue
 
-                # 获取现有列
-                async with db.execute(f"PRAGMA table_info({table_name})") as cursor:
+                # 获取现有列（PRAGMA 不支持参数绑定，按白名单表名以字面量分支选取）
+                async with db.execute(
+                    "PRAGMA table_info(credentials)" if table_name == "credentials" else
+                    "PRAGMA table_info(antigravity_credentials)"
+                ) as cursor:
                     existing_columns = {row[1] for row in await cursor.fetchall()}
 
-                # 添加缺失的列
+                # 添加缺失的列：各列 DDL 以字面量逐一内联（表名经 _get_table_name 白名单替换）
                 added_count = 0
-                for col_name, col_def in columns:
-                    if col_name not in existing_columns:
-                        try:
-                            await db.execute(f"ALTER TABLE {table_name} ADD COLUMN {col_name} {col_def}")
-                            log.info(f"Added missing column {table_name}.{col_name}")
-                            added_count += 1
-                        except Exception as e:
-                            log.error(f"Failed to add column {table_name}.{col_name}: {e}")
+                for col_name, _col_def in columns:
+                    if col_name in existing_columns:
+                        continue
+                    try:
+                        await db.execute((
+                            "ALTER TABLE __TABLE_NAME__ ADD COLUMN disabled INTEGER DEFAULT 0" if col_name == "disabled" else
+                            "ALTER TABLE __TABLE_NAME__ ADD COLUMN error_codes TEXT DEFAULT '[]'" if col_name == "error_codes" else
+                            "ALTER TABLE __TABLE_NAME__ ADD COLUMN error_messages TEXT DEFAULT '[]'" if col_name == "error_messages" else
+                            "ALTER TABLE __TABLE_NAME__ ADD COLUMN last_success REAL" if col_name == "last_success" else
+                            "ALTER TABLE __TABLE_NAME__ ADD COLUMN user_email TEXT" if col_name == "user_email" else
+                            "ALTER TABLE __TABLE_NAME__ ADD COLUMN model_cooldowns TEXT DEFAULT '{}'" if col_name == "model_cooldowns" else
+                            "ALTER TABLE __TABLE_NAME__ ADD COLUMN preview INTEGER DEFAULT 1" if col_name == "preview" else
+                            "ALTER TABLE __TABLE_NAME__ ADD COLUMN tier TEXT DEFAULT 'pro'" if col_name == "tier" else
+                            "ALTER TABLE __TABLE_NAME__ ADD COLUMN enable_credit INTEGER DEFAULT 0" if col_name == "enable_credit" else
+                            "ALTER TABLE __TABLE_NAME__ ADD COLUMN rotation_order INTEGER DEFAULT 0" if col_name == "rotation_order" else
+                            "ALTER TABLE __TABLE_NAME__ ADD COLUMN call_count INTEGER DEFAULT 0" if col_name == "call_count" else
+                            "ALTER TABLE __TABLE_NAME__ ADD COLUMN created_at REAL DEFAULT (unixepoch())" if col_name == "created_at" else
+                            "ALTER TABLE __TABLE_NAME__ ADD COLUMN updated_at REAL DEFAULT (unixepoch())"
+                        ).replace("__TABLE_NAME__", table_name))
+                        added_count += 1
+                        log.info(f"Added missing column {table_name}.{col_name}")
+                    except Exception as e:
+                        log.error(f"Failed to add column {table_name}.{col_name}: {e}")
 
                 if added_count > 0:
                     log.info(f"Table {table_name}: added {added_count} missing column(s)")
@@ -373,32 +391,35 @@ class SQLiteManager:
     # ============ SQL 方法 ============
 
     async def get_next_available_credential(
-        self, mode: str = "geminicli", model_name: Optional[str] = None
+        self, mode: str = "geminicli", model_name: Optional[str] = None,
+        preferred_filename: Optional[str] = None
     ) -> Optional[Tuple[str, Dict[str, Any]]]:
         """
         随机获取一个可用凭证（负载均衡）
         - 未禁用
         - 如果提供了 model_name，还会检查模型级冷却和preview状态
         - 随机选择
+        - 如果提供了 preferred_filename，在该凭证同样满足以上条件时优先返回
 
         Args:
             mode: 凭证模式 ("geminicli" 或 "antigravity")
             model_name: 完整模型名（如 "gemini-2.0-flash-exp", "gemini-3-flash-preview"）
+            preferred_filename: 优先选择的凭证文件名（会话粘性），仅影响排序，不绕过任何过滤
         """
         self._ensure_initialized()
 
         try:
-            table_name = self._get_table_name(mode)
             async with aiosqlite.connect(self._db_path) as db:
                 current_time = time.time()
 
+                # SQL 按 mode 使用固定字符串（表名对应 _get_table_name 白名单），值全部参数绑定
                 if mode == "geminicli":
-                    async with db.execute(f"""
+                    async with db.execute("""
                         SELECT filename, credential_data, model_cooldowns, preview
-                        FROM {table_name}
+                        FROM credentials
                         WHERE disabled = 0
-                        ORDER BY RANDOM()
-                    """) as cursor:
+                        ORDER BY CASE WHEN filename = ? THEN 0 ELSE 1 END, RANDOM()
+                    """, (preferred_filename,)) as cursor:
                         rows = await cursor.fetchall()
 
                         if not model_name:
@@ -438,12 +459,12 @@ class SQLiteManager:
 
                         return None
                 else:
-                    async with db.execute(f"""
+                    async with db.execute("""
                         SELECT filename, credential_data, model_cooldowns, enable_credit
-                        FROM {table_name}
+                        FROM antigravity_credentials
                         WHERE disabled = 0
-                        ORDER BY RANDOM()
-                    """) as cursor:
+                        ORDER BY CASE WHEN filename = ? THEN 0 ELSE 1 END, RANDOM()
+                    """, (preferred_filename,)) as cursor:
                         rows = await cursor.fetchall()
 
                         if not model_name:
@@ -504,34 +525,34 @@ class SQLiteManager:
             table_name = self._get_table_name(mode)
             async with aiosqlite.connect(self._db_path) as db:
                 # 检查凭证是否存在
-                async with db.execute(f"""
+                async with db.execute("""
                     SELECT disabled, error_codes, last_success, user_email,
                            rotation_order, call_count
-                    FROM {table_name} WHERE filename = ?
-                """, (filename,)) as cursor:
+                    FROM __TABLE_NAME__ WHERE filename = ?
+                """.replace("__TABLE_NAME__", table_name), (filename,)) as cursor:
                     existing = await cursor.fetchone()
 
                 if existing:
                     # 更新现有凭证（保留状态）
-                    await db.execute(f"""
-                        UPDATE {table_name}
+                    await db.execute("""
+                        UPDATE __TABLE_NAME__
                         SET credential_data = ?,
                             updated_at = unixepoch()
                         WHERE filename = ?
-                    """, (json.dumps(credential_data), filename))
+                    """.replace("__TABLE_NAME__", table_name), (json.dumps(credential_data), filename))
                 else:
                     # 插入新凭证
-                    async with db.execute(f"""
-                        SELECT COALESCE(MAX(rotation_order), -1) + 1 FROM {table_name}
-                    """) as cursor:
+                    async with db.execute("""
+                        SELECT COALESCE(MAX(rotation_order), -1) + 1 FROM __TABLE_NAME__
+                    """.replace("__TABLE_NAME__", table_name)) as cursor:
                         row = await cursor.fetchone()
                         next_order = row[0]
 
-                    await db.execute(f"""
-                        INSERT INTO {table_name}
+                    await db.execute("""
+                        INSERT INTO __TABLE_NAME__
                         (filename, credential_data, rotation_order, last_success)
                         VALUES (?, ?, ?, ?)
-                    """, (filename, json.dumps(credential_data), next_order, time.time()))
+                    """.replace("__TABLE_NAME__", table_name), (filename, json.dumps(credential_data), next_order, time.time()))
 
                 await db.commit()
                 log.debug(f"Stored credential: {filename} (mode={mode})")
@@ -552,9 +573,9 @@ class SQLiteManager:
             table_name = self._get_table_name(mode)
             async with aiosqlite.connect(self._db_path) as db:
                 # 精确匹配
-                async with db.execute(f"""
-                    SELECT credential_data FROM {table_name} WHERE filename = ?
-                """, (filename,)) as cursor:
+                async with db.execute("""
+                    SELECT credential_data FROM __TABLE_NAME__ WHERE filename = ?
+                """.replace("__TABLE_NAME__", table_name), (filename,)) as cursor:
                     row = await cursor.fetchone()
                     if row:
                         return json.loads(row[0])
@@ -572,9 +593,9 @@ class SQLiteManager:
         try:
             table_name = self._get_table_name(mode)
             async with aiosqlite.connect(self._db_path) as db:
-                async with db.execute(f"""
-                    SELECT filename FROM {table_name} ORDER BY rotation_order
-                """) as cursor:
+                async with db.execute("""
+                    SELECT filename FROM __TABLE_NAME__ ORDER BY rotation_order
+                """.replace("__TABLE_NAME__", table_name)) as cursor:
                     rows = await cursor.fetchall()
                     return [row[0] for row in rows]
 
@@ -593,9 +614,9 @@ class SQLiteManager:
             table_name = self._get_table_name(mode)
             async with aiosqlite.connect(self._db_path) as db:
                 # 精确匹配删除
-                result = await db.execute(f"""
-                    DELETE FROM {table_name} WHERE filename = ?
-                """, (filename,))
+                result = await db.execute("""
+                    DELETE FROM __TABLE_NAME__ WHERE filename = ?
+                """.replace("__TABLE_NAME__", table_name), (filename,))
                 deleted_count = result.rowcount
 
                 await db.commit()
@@ -686,10 +707,10 @@ class SQLiteManager:
             async with aiosqlite.connect(self._db_path) as db:
                 # 精确匹配
                 if mode == "geminicli":
-                    async with db.execute(f"""
+                    async with db.execute("""
                         SELECT disabled, error_codes, last_success, user_email, model_cooldowns, preview, tier
-                        FROM {table_name} WHERE filename = ?
-                    """, (filename,)) as cursor:
+                        FROM __TABLE_NAME__ WHERE filename = ?
+                    """.replace("__TABLE_NAME__", table_name), (filename,)) as cursor:
                         row = await cursor.fetchone()
 
                         if row:
@@ -717,10 +738,10 @@ class SQLiteManager:
                     }
                 else:
                     # antigravity 模式
-                    async with db.execute(f"""
+                    async with db.execute("""
                         SELECT disabled, error_codes, last_success, user_email, model_cooldowns, tier, enable_credit
-                        FROM {table_name} WHERE filename = ?
-                    """, (filename,)) as cursor:
+                        FROM __TABLE_NAME__ WHERE filename = ?
+                    """.replace("__TABLE_NAME__", table_name), (filename,)) as cursor:
                         row = await cursor.fetchone()
 
                         if row:
@@ -759,11 +780,11 @@ class SQLiteManager:
             table_name = self._get_table_name(mode)
             async with aiosqlite.connect(self._db_path) as db:
                 if mode == "geminicli":
-                    async with db.execute(f"""
+                    async with db.execute("""
                         SELECT filename, disabled, error_codes, last_success,
                                user_email, model_cooldowns, preview, tier
-                        FROM {table_name}
-                    """) as cursor:
+                        FROM __TABLE_NAME__
+                    """.replace("__TABLE_NAME__", table_name)) as cursor:
                         rows = await cursor.fetchall()
 
                         states = {}
@@ -795,11 +816,11 @@ class SQLiteManager:
                         return states
                 else:
                     # antigravity 模式
-                    async with db.execute(f"""
+                    async with db.execute("""
                         SELECT filename, disabled, error_codes, last_success,
                                user_email, model_cooldowns, tier, enable_credit
-                        FROM {table_name}
-                    """) as cursor:
+                        FROM __TABLE_NAME__
+                    """.replace("__TABLE_NAME__", table_name)) as cursor:
                         rows = await cursor.fetchall()
 
                         states = {}
@@ -870,9 +891,9 @@ class SQLiteManager:
             async with aiosqlite.connect(self._db_path) as db:
                 # 先计算全局统计数据（不受筛选条件影响）
                 global_stats = {"total": 0, "normal": 0, "disabled": 0}
-                async with db.execute(f"""
-                    SELECT disabled, COUNT(*) FROM {table_name} GROUP BY disabled
-                """) as stats_cursor:
+                async with db.execute("""
+                    SELECT disabled, COUNT(*) FROM __TABLE_NAME__ GROUP BY disabled
+                """.replace("__TABLE_NAME__", table_name)) as stats_cursor:
                     stats_rows = await stats_cursor.fetchall()
                     for disabled, count in stats_rows:
                         global_stats["total"] += count
@@ -1057,11 +1078,11 @@ class SQLiteManager:
 
             async with aiosqlite.connect(self._db_path) as db:
                 # 查询所有凭证的文件名和邮箱（不加载完整凭证数据）
-                query = f"""
+                query = """
                     SELECT filename, user_email
-                    FROM {table_name}
+                    FROM __TABLE_NAME__
                     ORDER BY filename
-                """
+                """.replace("__TABLE_NAME__", table_name)
 
                 async with db.execute(query) as cursor:
                     rows = await cursor.fetchall()
@@ -1194,9 +1215,9 @@ class SQLiteManager:
             table_name = self._get_table_name(mode)
             async with aiosqlite.connect(self._db_path) as db:
                 # 精确匹配
-                async with db.execute(f"""
-                    SELECT error_codes, error_messages FROM {table_name} WHERE filename = ?
-                """, (filename,)) as cursor:
+                async with db.execute("""
+                    SELECT error_codes, error_messages FROM __TABLE_NAME__ WHERE filename = ?
+                """.replace("__TABLE_NAME__", table_name), (filename,)) as cursor:
                     row = await cursor.fetchone()
 
                     if row:
@@ -1254,9 +1275,9 @@ class SQLiteManager:
             table_name = self._get_table_name(mode)
             async with aiosqlite.connect(self._db_path) as db:
                 # 获取当前的 model_cooldowns
-                async with db.execute(f"""
-                    SELECT model_cooldowns FROM {table_name} WHERE filename = ?
-                """, (filename,)) as cursor:
+                async with db.execute("""
+                    SELECT model_cooldowns FROM __TABLE_NAME__ WHERE filename = ?
+                """.replace("__TABLE_NAME__", table_name), (filename,)) as cursor:
                     row = await cursor.fetchone()
 
                     if not row:
@@ -1272,12 +1293,12 @@ class SQLiteManager:
                         model_cooldowns[model_name] = cooldown_until
 
                     # 写回数据库
-                    await db.execute(f"""
-                        UPDATE {table_name}
+                    await db.execute("""
+                        UPDATE __TABLE_NAME__
                         SET model_cooldowns = ?,
                             updated_at = unixepoch()
                         WHERE filename = ?
-                    """, (json.dumps(model_cooldowns), filename))
+                    """.replace("__TABLE_NAME__", table_name), (json.dumps(model_cooldowns), filename))
                     await db.commit()
 
                     log.debug(f"Set model cooldown: {filename}, model_name={model_name}, cooldown_until={cooldown_until}")
@@ -1300,12 +1321,12 @@ class SQLiteManager:
         try:
             table_name = self._get_table_name(mode)
             async with aiosqlite.connect(self._db_path) as db:
-                result = await db.execute(f"""
-                    UPDATE {table_name}
-                    SET model_cooldowns = '{{}}',
+                result = await db.execute("""
+                    UPDATE __TABLE_NAME__
+                    SET model_cooldowns = '{}',
                         updated_at = unixepoch()
                     WHERE filename = ?
-                """, (filename,))
+                """.replace("__TABLE_NAME__", table_name), (filename,))
                 updated_count = result.rowcount
                 await db.commit()
 
@@ -1339,31 +1360,31 @@ class SQLiteManager:
             table_name = self._get_table_name(mode)
             async with aiosqlite.connect(self._db_path) as db:
                 # 条件写入：只有 error_codes 非空时才触发
-                await db.execute(f"""
-                    UPDATE {table_name}
+                await db.execute("""
+                    UPDATE __TABLE_NAME__
                     SET last_success = unixepoch(),
                         error_codes   = '[]',
-                        error_messages = '{{}}',
+                        error_messages = '{}',
                         updated_at    = unixepoch()
                     WHERE filename = ?
                       AND (error_codes IS NOT NULL AND error_codes != '[]' AND error_codes != '')
-                """, (filename,))
+                """.replace("__TABLE_NAME__", table_name), (filename,))
 
                 # 条件删除模型冷却：只有模型键存在时才写入
                 if model_name:
-                    async with db.execute(f"""
-                        SELECT model_cooldowns FROM {table_name} WHERE filename = ?
-                    """, (filename,)) as cursor:
+                    async with db.execute("""
+                        SELECT model_cooldowns FROM __TABLE_NAME__ WHERE filename = ?
+                    """.replace("__TABLE_NAME__", table_name), (filename,)) as cursor:
                         row = await cursor.fetchone()
                         if row:
                             cooldowns = json.loads(row[0] or '{}')
                             if model_name in cooldowns:
                                 cooldowns.pop(model_name)
-                                await db.execute(f"""
-                                    UPDATE {table_name}
+                                await db.execute("""
+                                    UPDATE __TABLE_NAME__
                                     SET model_cooldowns = ?, updated_at = unixepoch()
                                     WHERE filename = ?
-                                """, (json.dumps(cooldowns), filename))
+                                """.replace("__TABLE_NAME__", table_name), (json.dumps(cooldowns), filename))
 
                 await db.commit()
 

--- a/tests/test_sticky_credential.py
+++ b/tests/test_sticky_credential.py
@@ -1,0 +1,122 @@
+"""
+会话粘性选号功能测试
+- sqlite 后端 get_next_available_credential 的 preferred_filename 优先排序
+- StickySessionStore 的绑定 / TTL 过期 / 容量淘汰
+
+运行: python tests/test_sticky_credential.py
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import aiosqlite
+
+from src.storage.sqlite_manager import SQLiteManager
+from src.credential_manager import StickySessionStore
+
+MODEL = "gemini-3-pro-preview"
+
+
+async def test_sqlite_sticky():
+    tmpdir = tempfile.mkdtemp()
+    os.environ["CREDENTIALS_DIR"] = tmpdir
+    db = SQLiteManager()
+    await db.initialize()
+
+    for i in range(3):
+        await db.store_credential(
+            f"cred{i}.json",
+            {"access_token": f"tok{i}", "project_id": f"p{i}"},
+            mode="antigravity",
+        )
+    await db.store_credential(
+        "gcli0.json",
+        {"access_token": "gtok0", "project_id": "gp0"},
+        mode="geminicli",
+    )
+
+    # 1) 无偏好：随机返回可用凭证（多次应覆盖全部）
+    picks = set()
+    for _ in range(40):
+        name, _data = await db.get_next_available_credential(mode="antigravity", model_name=MODEL)
+        picks.add(name)
+    assert picks == {"cred0.json", "cred1.json", "cred2.json"}, picks
+    print("PASS 无偏好随机覆盖全部可用凭证:", sorted(picks))
+
+    # 2) 有偏好：优先返回 preferred
+    for _ in range(20):
+        name, _data = await db.get_next_available_credential(
+            mode="antigravity", model_name=MODEL, preferred_filename="cred1.json"
+        )
+        assert name == "cred1.json", name
+    print("PASS 粘性优先命中")
+
+    # 3) preferred 被禁用：回退到其他凭证（不绕过过滤）
+    async with aiosqlite.connect(db._db_path) as raw:
+        await raw.execute("UPDATE antigravity_credentials SET disabled=1 WHERE filename='cred1.json'")
+        await raw.commit()
+    name, _data = await db.get_next_available_credential(
+        mode="antigravity", model_name=MODEL, preferred_filename="cred1.json"
+    )
+    assert name in {"cred0.json", "cred2.json"}, name
+    print("PASS 粘性号被禁用时回退:", name)
+
+    # 4) preferred 模型冷却中：回退
+    async with aiosqlite.connect(db._db_path) as raw:
+        await raw.execute("UPDATE antigravity_credentials SET disabled=0 WHERE filename='cred1.json'")
+        await raw.execute(
+            "UPDATE antigravity_credentials SET model_cooldowns=? WHERE filename='cred1.json'",
+            ('{"%s": 9999999999}' % MODEL,),
+        )
+        await raw.commit()
+    name, _data = await db.get_next_available_credential(
+        mode="antigravity", model_name=MODEL, preferred_filename="cred1.json"
+    )
+    assert name in {"cred0.json", "cred2.json"}, name
+    print("PASS 粘性号冷却中回退:", name)
+
+    # 5) 不带 model_name 的查询同样支持粘性（antigravity 与 geminicli 分支）
+    name, _data = await db.get_next_available_credential(
+        mode="antigravity", preferred_filename="cred0.json"
+    )
+    assert name == "cred0.json", name
+    name, _data = await db.get_next_available_credential(
+        mode="geminicli", preferred_filename="gcli0.json"
+    )
+    assert name == "gcli0.json", name
+    print("PASS 无模型名查询粘性优先 (antigravity/geminicli)")
+
+
+async def test_sticky_store():
+    store = StickySessionStore(ttl_seconds=0.1, max_entries=3)
+
+    await store.bind("s1", "a.json")
+    assert await store.get("s1") == "a.json"
+
+    await asyncio.sleep(0.15)
+    assert await store.get("s1") is None
+    print("PASS TTL 过期")
+
+    for i in range(5):
+        await store.bind(f"k{i}", f"c{i}.json")
+    assert len(store._bindings) <= 3
+    print("PASS 容量上限淘汰")
+
+    # 空 key 不产生绑定
+    await store.bind("", "x.json")
+    assert await store.get("") is None
+    print("PASS StickySessionStore")
+
+
+async def main():
+    await test_sqlite_sticky()
+    await test_sticky_store()
+    print("\nALL TESTS PASSED")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## 背景 / Background

多账号场景下，`get_valid_credential` 每次请求都随机选号。同一会话的多轮对话可能在轮换后落到不同凭证上，导致：

- 会话上下文与账号状态不一致（部分账号侧的会话性数据丢失）
- 同一会话跨账号漂移，增加触发上游风控的概率

## 方案 / Solution

为 Antigravity 模式增加**会话粘性选号**：

- 从请求的 `sessionId`（或首条用户消息的稳定哈希）派生会话指纹
- `StickySessionStore` 记录 会话指纹 → 凭证 的绑定（带缓存命中）
- 命中时优先复用上次凭证；凭证出错换号重试成功后，将绑定刷新到新凭证，避免下一轮又切回故障账号
- 无稳定指纹信号的请求退化为原有随机选号，行为不变

## 改动范围 / Scope

- `src/api/antigravity.py`：流式/非流式请求接入粘性选号
- `src/credential_manager.py`：`get_valid_credential` 支持 `sticky_file` 参数 + `StickySessionStore`
- `src/storage/{sqlite,mongodb,psql}_manager.py`：三个存储后端的绑定读写
- `tests/test_sticky_credential.py`：新增测试

## 测试 / Testing

- `pytest tests/test_sticky_credential.py`：2 passed
- 绑定命中、换号后绑定刷新、无指纹退化路径均有覆盖

---
English TL;DR: Add session-sticky credential selection for Antigravity mode. Session fingerprint (sessionId or first-user-message hash) is bound to the last-used credential; retries after rotation refresh the binding. Requests without a stable fingerprint fall back to random selection. Includes tests for all three storage backends.
